### PR TITLE
Linux: Include all test cases

### DIFF
--- a/Tests/InkTests/CodeTests.swift
+++ b/Tests/InkTests/CodeTests.swift
@@ -62,3 +62,15 @@ final class CodeTests: XCTestCase {
         """)
     }
 }
+
+extension CodeTests {
+    static var allTests: [(String, TestClosure<CodeTests>)] {
+        return [
+            ("testInlineCode", testInlineCode),
+            ("testCodeBlockWithJustBackticks", testCodeBlockWithJustBackticks),
+            ("testCodeBlockWithBackticksAndLabel", testCodeBlockWithBackticksAndLabel),
+            ("testEncodingSpecialCharactersWithinCodeBlock", testEncodingSpecialCharactersWithinCodeBlock),
+            ("testIgnoringFormattingWithinCodeBlock", testIgnoringFormattingWithinCodeBlock)
+        ]
+    }
+}

--- a/Tests/InkTests/HTMLTests.swift
+++ b/Tests/InkTests/HTMLTests.swift
@@ -94,3 +94,20 @@ final class HTMLTests: XCTestCase {
         XCTAssertEqual(html, "<p>Hello</p><br/><p>World</p>")
     }
 }
+
+extension HTMLTests {
+    static var allTests: [(String, TestClosure<HTMLTests>)] {
+        return [
+            ("testTopLevelHTML", testTopLevelHTML),
+            ("testNestedTopLevelHTML", testNestedTopLevelHTML),
+            ("testTopLevelHTMLWithPreviousNewline", testTopLevelHTMLWithPreviousNewline),
+            ("testIgnoringFormattingWithinTopLevelHTML", testIgnoringFormattingWithinTopLevelHTML),
+            ("testIgnoringTextFormattingWithinInlineHTML", testIgnoringTextFormattingWithinInlineHTML),
+            ("testIgnoringListsWithinInlineHTML", testIgnoringListsWithinInlineHTML),
+            ("testInlineParagraphTagEndingCurrentParagraph", testInlineParagraphTagEndingCurrentParagraph),
+            ("testTopLevelSelfClosingHTMLElement", testTopLevelSelfClosingHTMLElement),
+            ("testInlineSelfClosingHTMLElement", testInlineSelfClosingHTMLElement),
+            ("testTopLevelHTMLLineBreak", testTopLevelHTMLLineBreak)
+        ]
+    }
+}

--- a/Tests/InkTests/HeadingTests.swift
+++ b/Tests/InkTests/HeadingTests.swift
@@ -47,3 +47,16 @@ final class HeadingTests: XCTestCase {
         XCTAssertEqual(html, "<p>\(markdown)</p>")
     }
 }
+
+extension HeadingTests {
+    static var allTests: [(String, TestClosure<HeadingTests>)] {
+        return [
+            ("testHeading", testHeading),
+            ("testHeadingsSeparatedBySingleNewline", testHeadingsSeparatedBySingleNewline),
+            ("testHeadingsWithLeadingNumbers", testHeadingsWithLeadingNumbers),
+            ("testHeadingWithPreviousWhitespace", testHeadingWithPreviousWhitespace),
+            ("testHeadingWithPreviousNewlineAndWhitespace", testHeadingWithPreviousNewlineAndWhitespace),
+            ("testInvalidHeaderLevel", testInvalidHeaderLevel)
+        ]
+    }
+}

--- a/Tests/InkTests/HorizontalLineTests.swift
+++ b/Tests/InkTests/HorizontalLineTests.swift
@@ -37,3 +37,13 @@ final class HorizontalLineTests: XCTestCase {
         XCTAssertEqual(html, "<p>Hello</p><hr/><p>World</p>")
     }
 }
+
+extension HorizontalLineTests {
+    static var allTests: [(String, TestClosure<HorizontalLineTests>)] {
+        return [
+            ("testHorizonalLineWithDashes", testHorizonalLineWithDashes),
+            ("testHorizontalLineWithDashesAtTheStartOfString", testHorizontalLineWithDashesAtTheStartOfString),
+            ("testHorizontalLineWithAsterisks", testHorizontalLineWithAsterisks)
+        ]
+    }
+}

--- a/Tests/InkTests/ImageTests.swift
+++ b/Tests/InkTests/ImageTests.swift
@@ -41,3 +41,15 @@ final class ImageTests: XCTestCase {
         XCTAssertEqual(html, #"<p>Text <img src="url"/> text</p>"#)
     }
 }
+
+extension ImageTests {
+    static var allTests: [(String, TestClosure<ImageTests>)] {
+        return [
+            ("testImageWithURL", testImageWithURL),
+            ("testImageWithReference", testImageWithReference),
+            ("testImageWithURLAndAltText", testImageWithURLAndAltText),
+            ("testImageWithReferenceAndAltText", testImageWithReferenceAndAltText),
+            ("testImageWithinParagraph", testImageWithinParagraph)
+        ]
+    }
+}

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -48,3 +48,16 @@ final class LinkTests: XCTestCase {
         XCTAssertEqual(html, "<p><a href=\"/he_llo\">He_llo</a></p>")
     }
 }
+
+extension LinkTests {
+    static var allTests: [(String, TestClosure<LinkTests>)] {
+        return [
+            ("testLinkWithURL", testLinkWithURL),
+            ("testLinkWithReference", testLinkWithReference),
+            ("testNumericLinkWithReference", testNumericLinkWithReference),
+            ("testBoldLinkWithInternalMarkers", testBoldLinkWithInternalMarkers),
+            ("testBoldLinkWithExternalMarkers", testBoldLinkWithExternalMarkers),
+            ("testLinkWithUnderscores", testLinkWithUnderscores)
+        ]
+    }
+}

--- a/Tests/InkTests/ListTests.swift
+++ b/Tests/InkTests/ListTests.swift
@@ -95,3 +95,17 @@ final class ListTests: XCTestCase {
         XCTAssertEqual(html, "<ul><li>One -Two</li><li>Three</li></ul>")
     }
 }
+
+extension ListTests {
+    static var allTests: [(String, TestClosure<ListTests>)] {
+        return [
+            ("testOrderedList", testOrderedList),
+            ("testOrderedListWithoutIncrementedNumbers", testOrderedListWithoutIncrementedNumbers),
+            ("testOrderedListWithInvalidNumbers", testOrderedListWithInvalidNumbers),
+            ("testUnorderedList", testUnorderedList),
+            ("testUnorderedListWithMultiLineItem", testUnorderedListWithMultiLineItem),
+            ("testUnorderedListWithNestedList", testUnorderedListWithNestedList),
+            ("testUnorderedListWithInvalidMarker", testUnorderedListWithInvalidMarker)
+        ]
+    }
+}

--- a/Tests/InkTests/MetadataTests.swift
+++ b/Tests/InkTests/MetadataTests.swift
@@ -67,3 +67,14 @@ final class MetadataTests: XCTestCase {
         XCTAssertEqual(markdown.html, "<h1>Title</h1>")
     }
 }
+
+extension MetadataTests {
+    static var allTests: [(String, TestClosure<MetadataTests>)] {
+        return [
+            ("testParsingMetadata", testParsingMetadata),
+            ("testDiscardingEmptyMetadataValues", testDiscardingEmptyMetadataValues),
+            ("testMergingOrphanMetadataValueIntoPreviousOne", testMergingOrphanMetadataValueIntoPreviousOne),
+            ("testMissingMetadata", testMissingMetadata)
+        ]
+    }
+}

--- a/Tests/InkTests/ModifierTests.swift
+++ b/Tests/InkTests/ModifierTests.swift
@@ -77,3 +77,14 @@ final class ModifierTests: XCTestCase {
         XCTAssertEqual(html, "<p>Code is cool:</p><pre><code>Code</code></pre>")
     }
 }
+
+extension ModifierTests {
+    static var allTests: [(String, TestClosure<ModifierTests>)] {
+        return [
+            ("testModifierInput", testModifierInput),
+            ("testInitializingParserWithModifiers", testInitializingParserWithModifiers),
+            ("testAddingModifiers", testAddingModifiers),
+            ("testMultipleModifiersForSameTarget", testMultipleModifiersForSameTarget)
+        ]
+    }
+}

--- a/Tests/InkTests/TestClosure.swift
+++ b/Tests/InkTests/TestClosure.swift
@@ -1,0 +1,9 @@
+/**
+*  Ink
+*  Copyright (c) John Sundell 2019
+*  MIT license, see LICENSE file for details
+*/
+
+import XCTest
+
+typealias TestClosure<T: XCTestCase> = (T) -> () throws -> Void

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -137,3 +137,34 @@ final class TextFormattingTests: XCTestCase {
         XCTAssertEqual(html, "<p># Not a title *Not italic*</p>")
     }
 }
+
+extension TextFormattingTests {
+    static var allTests: [(String, TestClosure<TextFormattingTests>)] {
+        return [
+            ("testParagraph", testParagraph),
+            ("testItalicText", testItalicText),
+            ("testBoldText", testBoldText),
+            ("testItalicBoldText", testItalicBoldText),
+            ("testItalicBoldTextWithSeparateStartMarkers", testItalicBoldTextWithSeparateStartMarkers),
+            ("testItalicTextWithinBoldText", testItalicTextWithinBoldText),
+            ("testBoldTextWithinItalicText", testBoldTextWithinItalicText),
+            ("testItalicTextWithExtraLeadingMarkers", testItalicTextWithExtraLeadingMarkers),
+            ("testBoldTextWithExtraLeadingMarkers", testBoldTextWithExtraLeadingMarkers),
+            ("testItalicTextWithExtraTrailingMarkers", testItalicTextWithExtraTrailingMarkers),
+            ("testBoldTextWithExtraTrailingMarkers", testBoldTextWithExtraTrailingMarkers),
+            ("testItalicBoldTextWithExtraTrailingMarkers", testItalicBoldTextWithExtraTrailingMarkers),
+            ("testUnterminatedItalicMarker", testUnterminatedItalicMarker),
+            ("testUnterminatedBoldMarker", testUnterminatedBoldMarker),
+            ("testUnterminatedItalicBoldMarker", testUnterminatedItalicBoldMarker),
+            ("testUnterminatedItalicMarkerWithinBoldText", testUnterminatedItalicMarkerWithinBoldText),
+            ("testUnterminatedBoldMarkerWithinItalicText", testUnterminatedBoldMarkerWithinItalicText),
+            ("testStrikethroughText", testStrikethroughText),
+            ("testSingleTildeWithinStrikethroughText", testSingleTildeWithinStrikethroughText),
+            ("testUnterminatedStrikethroughMarker", testUnterminatedStrikethroughMarker),
+            ("testEncodingSpecialCharacters", testEncodingSpecialCharacters),
+            ("testSingleLineBlockquote", testSingleLineBlockquote),
+            ("testMultiLineBlockquote", testMultiLineBlockquote),
+            ("testEscapingSymbolsWithBackslash", testEscapingSymbolsWithBackslash)
+        ]
+    }
+}

--- a/Tests/InkTests/XCTestManifests.swift
+++ b/Tests/InkTests/XCTestManifests.swift
@@ -9,11 +9,15 @@ import XCTest
 #if !canImport(ObjectiveC)
 public func allTests() -> [XCTestCaseEntry] {
     return [
-        testCase(InkTests.allTests),
+        testCase(CodeTests.allTests),
         testCase(HeadingTests.allTests),
+        testCase(HorizontalLineTests.allTests),
         testCase(HTMLTests.allTests),
         testCase(ImageTests.allTests),
         testCase(LinkTests.allTests),
+        testCase(ListTests.allTests),
+        testCase(MetadataTests.allTests),
+        testCase(ModifierTests.allTests),
         testCase(TextFormattingTests.allTests)
     ]
 }


### PR DESCRIPTION
This change makes all tests run on Linux, by including them in the array returned by the `allTests()` function.