### PR TITLE
Add test to check generated HTML when Markdown contains a HTML comment

### DIFF
--- a/Tests/InkTests/HTMLTests.swift
+++ b/Tests/InkTests/HTMLTests.swift
@@ -93,6 +93,16 @@ final class HTMLTests: XCTestCase {
 
         XCTAssertEqual(html, "<p>Hello</p><br/><p>World</p>")
     }
+  
+    func testHTMLCommentInMarkdown() {
+      let html = MarkdownParser().html(from: """
+      Hello
+      <!-- some comment -->
+      World
+      """)
+
+      XCTAssertEqual(html, "<p>Hello</p><br/><p>World</p>")
+    }
 }
 
 extension HTMLTests {


### PR DESCRIPTION
It appears that generated HTML "clumps together" all content that is placed after an HTML comment (`<!-- comment -->`).

I tried to add a failing unit test to cover this case, but currently I'm unable to run tests from Xcode as I get this error:

```
dyld: Library not loaded: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Ink.framework/Versions/A/Ink
  Referenced from: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/HIToolbox
  Reason: Incompatible library version: HIToolbox requires version 1.0.0 or later, but Ink provides version 0.0.0
Program ended with exit code: 9
```

It seems like similar errors are [reported on StackOverflow](https://stackoverflow.com/search?q=Reason%3A+Incompatible+library+version%3A++requires+version+1.0.0+or+later%2C+but++provides+version+0.0.0), but so far I haven't been able to find the "correct answer".
