### PR TITLE
Fixed String index out of bounds error

### DIFF
--- a/Sources/Ink/Internal/Link.swift
+++ b/Sources/Ink/Internal/Link.swift
@@ -15,6 +15,8 @@ internal struct Link: Fragment {
         let text = FormattedText.read(using: &reader, terminator: "]")
         try reader.read("]")
 
+        guard !reader.didReachEnd else { throw Reader.Error() }
+
         if reader.currentCharacter == "(" {
             reader.advanceIndex()
             let url = try reader.read(until: ")")

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -48,7 +48,7 @@ final class LinkTests: XCTestCase {
         XCTAssertEqual(html, "<p><a href=\"/he_llo\">He_llo</a></p>")
     }
 
-    func testFakeLink() {
+    func testUnterminatedLink() {
         let html = MarkdownParser().html(from: "[Hello]")
         XCTAssertEqual(html, "<p>[Hello]</p>")
     }
@@ -62,7 +62,8 @@ extension LinkTests {
             ("testNumericLinkWithReference", testNumericLinkWithReference),
             ("testBoldLinkWithInternalMarkers", testBoldLinkWithInternalMarkers),
             ("testBoldLinkWithExternalMarkers", testBoldLinkWithExternalMarkers),
-            ("testLinkWithUnderscores", testLinkWithUnderscores)
+            ("testLinkWithUnderscores", testLinkWithUnderscores),
+            ("testFakeLink", testUnterminatedLink)
         ]
     }
 }

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -63,7 +63,7 @@ extension LinkTests {
             ("testBoldLinkWithInternalMarkers", testBoldLinkWithInternalMarkers),
             ("testBoldLinkWithExternalMarkers", testBoldLinkWithExternalMarkers),
             ("testLinkWithUnderscores", testLinkWithUnderscores),
-            ("testFakeLink", testUnterminatedLink)
+            ("testUnterminatedLink", testUnterminatedLink)
         ]
     }
 }

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -47,6 +47,11 @@ final class LinkTests: XCTestCase {
         let html = MarkdownParser().html(from: "[He_llo](/he_llo)")
         XCTAssertEqual(html, "<p><a href=\"/he_llo\">He_llo</a></p>")
     }
+
+    func testFakeLink() {
+        let html = MarkdownParser().html(from: "[Hello]")
+        XCTAssertEqual(html, "<p>[Hello]</p>")
+    }
 }
 
 extension LinkTests {


### PR DESCRIPTION
If Markdown fragment ended with square brackets, parser would try to parse a link and overrun the last index of Reader.string, causing a crash.
Added guard to throw error in link parsing if end of string is reached.
Added test to confirm issue is fixed.