### PR TITLE
Add Docker support for CLI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.build
+.swiftpm
+Package.resolved

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Build
+FROM swift:5.1 as builder
+WORKDIR /ink
+COPY . .
+RUN mkdir -p /build/lib && cp -R /usr/lib/swift/linux/*.so* /build/lib
+RUN swift build -c release && mv `swift build -c release --show-bin-path` /build/bin
+
+# Release
+FROM ubuntu:18.04
+RUN apt-get -qq update \
+    && apt-get install -y libatomic1 \
+    && rm -r /var/lib/apt/lists/*
+WORKDIR /ink
+COPY --from=builder /build/bin/ink-cli .
+COPY --from=builder /build/lib/* /usr/lib/
+ENTRYPOINT ["./ink-cli"]


### PR DESCRIPTION
Just in case somebody wants to use the CLI.
It works like this(`ink` is the name of a built image):
```
$ docker run --rm ink '# Hello'
<h1>Hello</h1>
```
If you have a Docker Hub account it would be great to configure automatic builds.