### PR TITLE
Support parsing from stdin

### DIFF
--- a/Sources/InkCLI/main.swift
+++ b/Sources/InkCLI/main.swift
@@ -17,6 +17,9 @@ guard CommandLine.arguments.count > 1 else {
     exit(0)
 }
 
-let markdown = CommandLine.arguments[1]
+var markdown = CommandLine.arguments[1]
+if markdown == "-" {
+    markdown = AnyIterator { readLine() }.joined(separator: "\n")
+}
 let parser = MarkdownParser()
 print(parser.html(from: markdown))


### PR DESCRIPTION
I'm not quite sure about that solution.
Maybe it would be better to start parsing stdin when there is no argument passed, and show help message if there is a `-h` or `--help` or `-?` first argument?
In any case, I think that there should also be a proper help message describing how to use CLI.