### PR TITLE
Improved CommonMark Compatibility for Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ Ink supports the following Markdown features:
 - Links, using the following syntax: `[Title](url)`.
 - Images, using the following syntax: `![Alt text](image-url)`.
 - Both images and links can also use reference URLs, which can be defined anywhere in a Markdown document using this syntax: `[referenceName]: url`.
-- Both ordered lists (using numbers) and unordered lists (using either a dash (`-`), or an asterisk (`*`) as bullets) are supported.
+- Both ordered lists (using numbers followed by a period (`.`) or right parenthesis (`)`) as bullets) and unordered lists (using either a dash (`-`), plus (`+`), or asterisk (`*`) as bullets) are supported.
+- Ordered lists start from the index of the first entry
 - Nested lists are supported as well, by indenting any part of a list that should be nested within its parent.
 - Horizontal lines can be placed using either three asterisks (`***`) or three dashes (`---`) on a new line.
 - HTML can be inlined both at the root level, and within text paragraphs.

--- a/Sources/Ink/API/MarkdownParser.swift
+++ b/Sources/Ink/API/MarkdownParser.swift
@@ -117,7 +117,7 @@ private extension MarkdownParser {
         case "-" where character == nextCharacter,
              "*" where character == nextCharacter:
             return HorizontalLine.self
-        case "-", "*", \.isNumber: return List.self
+        case "-", "*", "+", \.isNumber: return List.self
         default: return Paragraph.self
         }
     }

--- a/Sources/Ink/Internal/List.swift
+++ b/Sources/Ink/Internal/List.swift
@@ -21,8 +21,7 @@ internal struct List: Fragment {
                              indentationLength: Int) throws -> List {
         let isOrdered = reader.currentCharacter.isNumber
 
-        var kind: Kind
-        let listMarker: Character
+        var list: List
         if isOrdered {
             let startIndex = reader.currentIndex
             defer { reader.moveToIndex(startIndex) }
@@ -30,14 +29,12 @@ internal struct List: Fragment {
             let startingIndexString = try reader.readCharacters(matching: \.isNumber, limit: 9)
             let startingIndex = Int(startingIndexString) ?? 1
             
-            listMarker = try reader.readCharacter(in: List.orderedListMarkers)
-            kind = .ordered(startingIndex: startingIndex)
+            let listMarker = try reader.readCharacter(in: List.orderedListMarkers)
+            list = List(listMarker: listMarker, kind: .ordered(startingIndex: startingIndex))
         } else {
-            listMarker = reader.currentCharacter
-            kind = .unordered
+            let listMarker = reader.currentCharacter
+            list = List(listMarker: listMarker, kind: .unordered)
         }
-    
-        var list = List(listMarker: listMarker, kind: kind)
 
         func addTextToLastItem() throws {
             try require(!list.items.isEmpty)
@@ -81,7 +78,7 @@ internal struct List: Fragment {
                     try addTextToLastItem()
                 }
             case \.isNumber:
-                guard case .ordered(_) = kind else {
+                guard case .ordered(_) = list.kind else {
                     try addTextToLastItem()
                     continue
                 }
@@ -92,7 +89,7 @@ internal struct List: Fragment {
                     try reader.readCharacters(matching: \.isNumber, limit: 9)
                     let foundMarker = try reader.readCharacter(in: List.orderedListMarkers)
 
-                    guard foundMarker == listMarker else {
+                    guard foundMarker == list.listMarker else {
                         reader.moveToIndex(startIndex)
                         return list
                     }

--- a/Sources/Ink/Internal/List.swift
+++ b/Sources/Ink/Internal/List.swift
@@ -26,7 +26,7 @@ internal struct List: Fragment {
             let startIndex = reader.currentIndex
             defer { reader.moveToIndex(startIndex) }
             
-            let startingIndexString = try reader.readCharacters(matching: \.isNumber, limit: 9)
+            let startingIndexString = try reader.readCharacters(matching: \.isNumber, max: 9)
             let startingIndex = Int(startingIndexString) ?? 1
             
             let listMarker = try reader.readCharacter(in: List.orderedListMarkers)
@@ -86,7 +86,7 @@ internal struct List: Fragment {
                 let startIndex = reader.currentIndex
 
                 do {
-                    try reader.readCharacters(matching: \.isNumber, limit: 9)
+                    try reader.readCharacters(matching: \.isNumber, max: 9)
                     let foundMarker = try reader.readCharacter(in: List.orderedListMarkers)
 
                     guard foundMarker == list.listMarker else {

--- a/Sources/Ink/Internal/List.swift
+++ b/Sources/Ink/Internal/List.swift
@@ -126,17 +126,17 @@ internal struct List: Fragment {
     func html(usingURLs urls: NamedURLCollection,
               modifiers: ModifierCollection) -> String {
         let tagName: String
-        let startAttr: String
+        let startAttribute: String
         switch kind {
         case .unordered:
             tagName = "ul"
-            startAttr = ""
+            startAttribute = ""
         case let .ordered(startingIndex):
             tagName = "ol"
             if startingIndex != 1 {
-                startAttr = #" start="\#(startingIndex)""#
+                startAttribute = #" start="\#(startingIndex)""#
             } else {
-                startAttr = ""
+                startAttribute = ""
             }
         }
 
@@ -144,11 +144,11 @@ internal struct List: Fragment {
             html.append(item.html(usingURLs: urls, modifiers: modifiers))
         }
 
-        return "<\(tagName)\(startAttr)>\(body)</\(tagName)>"
+        return "<\(tagName)\(startAttribute)>\(body)</\(tagName)>"
     }
 }
 
-extension List {
+private extension List {
     struct Item: HTMLConvertible {
         var text: FormattedText
         var nestedList: List? = nil
@@ -160,9 +160,7 @@ extension List {
             return "<li>\(textHTML)\(listHTML ?? "")</li>"
         }
     }
-}
 
-extension List {
     enum Kind {
         case unordered
         case ordered(firstNumber: Int)

--- a/Sources/Ink/Internal/List.swift
+++ b/Sources/Ink/Internal/List.swift
@@ -19,22 +19,22 @@ internal struct List: Fragment {
 
     private static func read(using reader: inout Reader,
                              indentationLength: Int) throws -> List {
+        let startIndex = reader.currentIndex
         let isOrdered = reader.currentCharacter.isNumber
 
         var list: List
         if isOrdered {
-            let startIndex = reader.currentIndex
-            defer { reader.moveToIndex(startIndex) }
-            
-            let startingIndexString = try reader.readCharacters(matching: \.isNumber, max: 9)
-            let startingIndex = Int(startingIndexString) ?? 1
+            let firstNumberString = try reader.readCharacters(matching: \.isNumber, max: 9)
+            let firstNumber = Int(firstNumberString) ?? 1
             
             let listMarker = try reader.readCharacter(in: List.orderedListMarkers)
-            list = List(listMarker: listMarker, kind: .ordered(startingIndex: startingIndex))
+            list = List(listMarker: listMarker, kind: .ordered(firstNumber: firstNumber))
         } else {
             let listMarker = reader.currentCharacter
             list = List(listMarker: listMarker, kind: .unordered)
         }
+
+        reader.moveToIndex(startIndex)
 
         func addTextToLastItem() throws {
             try require(!list.items.isEmpty)
@@ -165,6 +165,6 @@ extension List {
 extension List {
     enum Kind {
         case unordered
-        case ordered(startingIndex: Int)
+        case ordered(firstNumber: Int)
     }
 }

--- a/Sources/Ink/Internal/List.swift
+++ b/Sources/Ink/Internal/List.swift
@@ -126,7 +126,7 @@ internal struct List: Fragment {
         let tagName = isOrdered ? "ol" : "ul"
         
         let startAttr: String
-        if let startingIndex = startingIndex, startingIndex > 1 {
+        if let startingIndex = startingIndex, startingIndex != 1 {
             startAttr = #" start="\#(startingIndex)""#
         } else {
             startAttr = ""

--- a/Sources/Ink/Internal/Reader.swift
+++ b/Sources/Ink/Internal/Reader.swift
@@ -70,15 +70,17 @@ extension Reader {
     }
 
     @discardableResult
-    mutating func readCharacters(matching keyPath: KeyPath<Character, Bool>) throws -> Substring {
+    mutating func readCharacters(matching keyPath: KeyPath<Character, Bool>, limit: Int = Int.max) throws -> Substring {
         let startIndex = currentIndex
-
-        while !didReachEnd {
+        var readCount = 0
+        
+        while !didReachEnd && readCount < limit {
             guard currentCharacter[keyPath: keyPath] else {
                 break
             }
 
             advanceIndex()
+            readCount += 1
         }
 
         guard startIndex != currentIndex else {
@@ -86,6 +88,15 @@ extension Reader {
         }
 
         return string[startIndex..<currentIndex]
+    }
+    
+    @discardableResult
+    mutating func readCharacter(in set: Set<Character>) throws -> Character {
+        guard !didReachEnd else { throw Error() }
+        guard set.contains(currentCharacter) else { throw Error() }
+        defer { advanceIndex() }
+
+        return currentCharacter
     }
 
     @discardableResult

--- a/Sources/Ink/Internal/Reader.swift
+++ b/Sources/Ink/Internal/Reader.swift
@@ -69,18 +69,25 @@ extension Reader {
         return count
     }
 
+    /// Read characters that match by evaluating a keypath
+    ///
+    /// - Parameters:
+    ///   - keyPath: A keypath to evaluate that is `true` for target characters.
+    ///   - maxCount: The maximum number of characters to attempt to read.
+    /// - Returns: The substring of characters successfully read
+    /// - Complexity: O(*n*), where *n* is the length of the string being read.
     @discardableResult
-    mutating func readCharacters(matching keyPath: KeyPath<Character, Bool>, limit: Int = Int.max) throws -> Substring {
+    mutating func readCharacters(matching keyPath: KeyPath<Character, Bool>,
+                                 max maxCount: Int = Int.max) throws -> Substring {
         let startIndex = currentIndex
-        var readCount = 0
+        var count = 0
         
-        while !didReachEnd && readCount < limit {
-            guard currentCharacter[keyPath: keyPath] else {
-                break
-            }
+        while !didReachEnd
+              && count < maxCount
+              && currentCharacter[keyPath: keyPath] {
 
             advanceIndex()
-            readCount += 1
+            count += 1
         }
 
         guard startIndex != currentIndex else {
@@ -90,10 +97,16 @@ extension Reader {
         return string[startIndex..<currentIndex]
     }
     
+    /// Read a character that exist in a set
+    ///
+    /// - Parameters:
+    ///   - set: The set of valid characters.
+    /// - Returns: The character that matched.
+    /// - Complexity: O(1)
     @discardableResult
     mutating func readCharacter(in set: Set<Character>) throws -> Character {
         guard !didReachEnd else { throw Error() }
-        guard set.contains(currentCharacter) else { throw Error() }
+        guard currentCharacter.isAny(of: set) else { throw Error() }
         defer { advanceIndex() }
 
         return currentCharacter

--- a/Tests/InkTests/ListTests.swift
+++ b/Tests/InkTests/ListTests.swift
@@ -139,9 +139,13 @@ extension ListTests {
     static var allTests: Linux.TestList<ListTests> {
         return [
             ("testOrderedList", testOrderedList),
+            ("test10DigitOrderedList", test10DigitOrderedList),
+            ("testOrderedListParentheses", testOrderedListParentheses),
             ("testOrderedListWithoutIncrementedNumbers", testOrderedListWithoutIncrementedNumbers),
             ("testOrderedListWithInvalidNumbers", testOrderedListWithInvalidNumbers),
             ("testUnorderedList", testUnorderedList),
+            ("testMixedUnorderedList", testMixedUnorderedList),
+            ("testMixedList", testMixedList),
             ("testUnorderedListWithMultiLineItem", testUnorderedListWithMultiLineItem),
             ("testUnorderedListWithNestedList", testUnorderedListWithNestedList),
             ("testUnorderedListWithInvalidMarker", testUnorderedListWithInvalidMarker)

--- a/Tests/InkTests/ListTests.swift
+++ b/Tests/InkTests/ListTests.swift
@@ -19,10 +19,10 @@ final class ListTests: XCTestCase {
     
     func test10DigitOrderedList() {
         let html = MarkdownParser().html(from: """
-        1234567890. not a list
+        1234567890. Not a list
         """)
 
-        XCTAssertEqual(html, "<p>1234567890. not a list</p>")
+        XCTAssertEqual(html, "<p>1234567890. Not a list</p>")
     }
     
     func testOrderedListParentheses() {

--- a/Tests/InkTests/ListTests.swift
+++ b/Tests/InkTests/ListTests.swift
@@ -16,6 +16,23 @@ final class ListTests: XCTestCase {
 
         XCTAssertEqual(html, #"<ol><li>One</li><li>Two</li></ol>"#)
     }
+    
+    func test10DigitOrderedList() {
+        let html = MarkdownParser().html(from: """
+        1234567890. not a list
+        """)
+
+        XCTAssertEqual(html, "<p>1234567890. not a list</p>")
+    }
+    
+    func testOrderedListParentheses() {
+        let html = MarkdownParser().html(from: """
+        1) One
+        2) Two
+        """)
+
+        XCTAssertEqual(html, #"<ol><li>One</li><li>Two</li></ol>"#)
+    }
 
     func testOrderedListWithoutIncrementedNumbers() {
         let html = MarkdownParser().html(from: """
@@ -40,11 +57,33 @@ final class ListTests: XCTestCase {
     func testUnorderedList() {
         let html = MarkdownParser().html(from: """
         - One
-        * Two
+        - Two
         - Three
         """)
 
         XCTAssertEqual(html, "<ul><li>One</li><li>Two</li><li>Three</li></ul>")
+    }
+    
+    func testMixedUnorderedList() {
+        let html = MarkdownParser().html(from: """
+        - One
+        * Two
+        * Three
+        - Four
+        """)
+
+        XCTAssertEqual(html, "<ul><li>One</li></ul><ul><li>Two</li><li>Three</li></ul><ul><li>Four</li></ul>")
+    }
+    
+    func testMixedList() {
+        let html = MarkdownParser().html(from: """
+        1. One
+        2. Two
+        3) Three
+        * Four
+        """)
+        
+        XCTAssertEqual(html, #"<ol><li>One</li><li>Two</li></ol><ol start="3"><li>Three</li></ol><ul><li>Four</li></ul>"#)
     }
 
     func testUnorderedListWithMultiLineItem() {


### PR DESCRIPTION
This pull request adds conformation to the CommonMark spec in a number of areas:

- Added `+` as an unordered list marker [spec](https://spec.commonmark.org/0.29/#bullet-list-marker)
- Added `)` as an ordered list marker [spec](https://spec.commonmark.org/0.29/#ordered-list-marker)
- Start new lists when list marker changes [spec](https://spec.commonmark.org/0.29/#example-271)
- Make the first index of ordered lists significant [spec](https://spec.commonmark.org/0.29/#example-235)
- Limit numbered lists to 9 characters or less [spec](https://spec.commonmark.org/0.29/#example-236)

I'd love feedback on the code styles and choices, of course.