### PR TITLE
CLI: Add STDIN parsing to help message + tidy up code

### DIFF
--- a/Sources/InkCLI/main.swift
+++ b/Sources/InkCLI/main.swift
@@ -12,14 +12,18 @@ guard CommandLine.arguments.count > 1 else {
     Ink: Markdown -> HTML converter
     -------------------------------
     Pass a Markdown string to convert as input,
-    and HTML will be returned as output.
+    and HTML will be returned as output. To use
+    STDIN as input, call ink with "-" as a single
+    argument, like this: '$ ink -'.
     """)
     exit(0)
 }
 
 var markdown = CommandLine.arguments[1]
+
 if markdown == "-" {
     markdown = AnyIterator { readLine() }.joined(separator: "\n")
 }
+
 let parser = MarkdownParser()
 print(parser.html(from: markdown))


### PR DESCRIPTION
- Help message now includes that STDIN may be parsed by passing “-“.
- Two newlines were added to the code to make it a bit more readable.