### PR TITLE
Add tooling to verify that all tests run on Linux

### DIFF
--- a/Tests/InkTests/CodeTests.swift
+++ b/Tests/InkTests/CodeTests.swift
@@ -64,7 +64,7 @@ final class CodeTests: XCTestCase {
 }
 
 extension CodeTests {
-    static var allTests: [(String, TestClosure<CodeTests>)] {
+    static var allTests: Linux.TestList<CodeTests> {
         return [
             ("testInlineCode", testInlineCode),
             ("testCodeBlockWithJustBackticks", testCodeBlockWithJustBackticks),

--- a/Tests/InkTests/HTMLTests.swift
+++ b/Tests/InkTests/HTMLTests.swift
@@ -96,7 +96,7 @@ final class HTMLTests: XCTestCase {
 }
 
 extension HTMLTests {
-    static var allTests: [(String, TestClosure<HTMLTests>)] {
+    static var allTests: Linux.TestList<HTMLTests> {
         return [
             ("testTopLevelHTML", testTopLevelHTML),
             ("testNestedTopLevelHTML", testNestedTopLevelHTML),

--- a/Tests/InkTests/HeadingTests.swift
+++ b/Tests/InkTests/HeadingTests.swift
@@ -49,7 +49,7 @@ final class HeadingTests: XCTestCase {
 }
 
 extension HeadingTests {
-    static var allTests: [(String, TestClosure<HeadingTests>)] {
+    static var allTests: Linux.TestList<HeadingTests> {
         return [
             ("testHeading", testHeading),
             ("testHeadingsSeparatedBySingleNewline", testHeadingsSeparatedBySingleNewline),

--- a/Tests/InkTests/HorizontalLineTests.swift
+++ b/Tests/InkTests/HorizontalLineTests.swift
@@ -39,7 +39,7 @@ final class HorizontalLineTests: XCTestCase {
 }
 
 extension HorizontalLineTests {
-    static var allTests: [(String, TestClosure<HorizontalLineTests>)] {
+    static var allTests: Linux.TestList<HorizontalLineTests> {
         return [
             ("testHorizonalLineWithDashes", testHorizonalLineWithDashes),
             ("testHorizontalLineWithDashesAtTheStartOfString", testHorizontalLineWithDashesAtTheStartOfString),

--- a/Tests/InkTests/ImageTests.swift
+++ b/Tests/InkTests/ImageTests.swift
@@ -43,7 +43,7 @@ final class ImageTests: XCTestCase {
 }
 
 extension ImageTests {
-    static var allTests: [(String, TestClosure<ImageTests>)] {
+    static var allTests: Linux.TestList<ImageTests> {
         return [
             ("testImageWithURL", testImageWithURL),
             ("testImageWithReference", testImageWithReference),

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -55,7 +55,7 @@ final class LinkTests: XCTestCase {
 }
 
 extension LinkTests {
-    static var allTests: [(String, TestClosure<LinkTests>)] {
+    static var allTests: Linux.TestList<LinkTests> {
         return [
             ("testLinkWithURL", testLinkWithURL),
             ("testLinkWithReference", testLinkWithReference),

--- a/Tests/InkTests/LinuxCompatibility.swift
+++ b/Tests/InkTests/LinuxCompatibility.swift
@@ -9,10 +9,10 @@ import XCTest
 public enum Linux {}
 
 public extension Linux {
-    typealias TestCase = (type: XCTestCase.Type, manifest: TestManifest)
-    typealias TestManifest = [(name: String, runner: TestRunner)]
+    typealias TestCase = (testCaseClass: XCTestCase.Type, allTests: TestManifest)
+    typealias TestManifest = [(String, TestRunner)]
     typealias TestRunner = (XCTestCase) throws -> Void
-    typealias TestList<T: XCTestCase> = [(name: String, test: Test<T>)]
+    typealias TestList<T: XCTestCase> = [(String, Test<T>)]
     typealias Test<T: XCTestCase> = (T) -> () throws -> Void
 }
 
@@ -32,20 +32,20 @@ internal extension Linux {
 internal final class LinuxVerificationTests: XCTestCase {
     func testAllTestsRunOnLinux() {
         for testCase in allTests() {
-            let suite = testCase.type.defaultTestSuite
+            let type = testCase.testCaseClass
 
-            let testNames: [String] = suite.tests.map { test in
+            let testNames: [String] = type.defaultTestSuite.tests.map { test in
                 let components = test.name.components(separatedBy: .whitespaces)
                 return components[1].replacingOccurrences(of: "]", with: "")
             }
 
-            let linuxTestNames = Set(testCase.manifest.map { $0.name })
+            let linuxTestNames = Set(testCase.allTests.map { $0.0 })
 
             for name in testNames {
                 if !linuxTestNames.contains(name) {
                     XCTFail("""
-                    \(testCase.type).\(name) does not run on Linux.
-                    Please add it to \(testCase.type).allTests.
+                    \(type).\(name) does not run on Linux.
+                    Please add it to \(type).allTests.
                     """)
                 }
             }

--- a/Tests/InkTests/LinuxCompatibility.swift
+++ b/Tests/InkTests/LinuxCompatibility.swift
@@ -1,0 +1,55 @@
+/**
+*  Ink
+*  Copyright (c) John Sundell 2019
+*  MIT license, see LICENSE file for details
+*/
+
+import XCTest
+
+public enum Linux {}
+
+public extension Linux {
+    typealias TestCase = (type: XCTestCase.Type, manifest: TestManifest)
+    typealias TestManifest = [(name: String, runner: TestRunner)]
+    typealias TestRunner = (XCTestCase) throws -> Void
+    typealias TestList<T: XCTestCase> = [(name: String, test: Test<T>)]
+    typealias Test<T: XCTestCase> = (T) -> () throws -> Void
+}
+
+internal extension Linux {
+    static func makeTestCase<T: XCTestCase>(using list: TestList<T>) -> TestCase {
+        let manifest: TestManifest = list.map { name, function in
+            (name, { type in
+                try function(type as! T)()
+            })
+        }
+
+        return (T.self, manifest)
+    }
+}
+
+#if canImport(ObjectiveC)
+internal final class LinuxVerificationTests: XCTestCase {
+    func testAllTestsRunOnLinux() {
+        for testCase in allTests() {
+            let suite = testCase.type.defaultTestSuite
+
+            let testNames: [String] = suite.tests.map { test in
+                let components = test.name.components(separatedBy: .whitespaces)
+                return components[1].replacingOccurrences(of: "]", with: "")
+            }
+
+            let linuxTestNames = Set(testCase.manifest.map { $0.name })
+
+            for name in testNames {
+                if !linuxTestNames.contains(name) {
+                    XCTFail("""
+                    \(testCase.type).\(name) does not run on Linux.
+                    Please add it to \(testCase.type).allTests.
+                    """)
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Tests/InkTests/ListTests.swift
+++ b/Tests/InkTests/ListTests.swift
@@ -97,7 +97,7 @@ final class ListTests: XCTestCase {
 }
 
 extension ListTests {
-    static var allTests: [(String, TestClosure<ListTests>)] {
+    static var allTests: Linux.TestList<ListTests> {
         return [
             ("testOrderedList", testOrderedList),
             ("testOrderedListWithoutIncrementedNumbers", testOrderedListWithoutIncrementedNumbers),

--- a/Tests/InkTests/MetadataTests.swift
+++ b/Tests/InkTests/MetadataTests.swift
@@ -69,7 +69,7 @@ final class MetadataTests: XCTestCase {
 }
 
 extension MetadataTests {
-    static var allTests: [(String, TestClosure<MetadataTests>)] {
+    static var allTests: Linux.TestList<MetadataTests> {
         return [
             ("testParsingMetadata", testParsingMetadata),
             ("testDiscardingEmptyMetadataValues", testDiscardingEmptyMetadataValues),

--- a/Tests/InkTests/ModifierTests.swift
+++ b/Tests/InkTests/ModifierTests.swift
@@ -79,7 +79,7 @@ final class ModifierTests: XCTestCase {
 }
 
 extension ModifierTests {
-    static var allTests: [(String, TestClosure<ModifierTests>)] {
+    static var allTests: Linux.TestList<ModifierTests> {
         return [
             ("testModifierInput", testModifierInput),
             ("testInitializingParserWithModifiers", testInitializingParserWithModifiers),

--- a/Tests/InkTests/TestClosure.swift
+++ b/Tests/InkTests/TestClosure.swift
@@ -1,9 +1,0 @@
-/**
-*  Ink
-*  Copyright (c) John Sundell 2019
-*  MIT license, see LICENSE file for details
-*/
-
-import XCTest
-
-typealias TestClosure<T: XCTestCase> = (T) -> () throws -> Void

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -139,7 +139,7 @@ final class TextFormattingTests: XCTestCase {
 }
 
 extension TextFormattingTests {
-    static var allTests: [(String, TestClosure<TextFormattingTests>)] {
+    static var allTests: Linux.TestList<TextFormattingTests> {
         return [
             ("testParagraph", testParagraph),
             ("testItalicText", testItalicText),

--- a/Tests/InkTests/XCTestManifests.swift
+++ b/Tests/InkTests/XCTestManifests.swift
@@ -6,19 +6,17 @@
 
 import XCTest
 
-#if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
+public func allTests() -> [Linux.TestCase] {
     return [
-        testCase(CodeTests.allTests),
-        testCase(HeadingTests.allTests),
-        testCase(HorizontalLineTests.allTests),
-        testCase(HTMLTests.allTests),
-        testCase(ImageTests.allTests),
-        testCase(LinkTests.allTests),
-        testCase(ListTests.allTests),
-        testCase(MetadataTests.allTests),
-        testCase(ModifierTests.allTests),
-        testCase(TextFormattingTests.allTests)
+        Linux.makeTestCase(using: CodeTests.allTests),
+        Linux.makeTestCase(using: HeadingTests.allTests),
+        Linux.makeTestCase(using: HorizontalLineTests.allTests),
+        Linux.makeTestCase(using: HTMLTests.allTests),
+        Linux.makeTestCase(using: ImageTests.allTests),
+        Linux.makeTestCase(using: LinkTests.allTests),
+        Linux.makeTestCase(using: ListTests.allTests),
+        Linux.makeTestCase(using: MetadataTests.allTests),
+        Linux.makeTestCase(using: ModifierTests.allTests),
+        Linux.makeTestCase(using: TextFormattingTests.allTests)
     ]
 }
-#endif


### PR DESCRIPTION
Since the Swift Package Manager requires all tests to be manually declared on Linux, add a test that runs on macOS that identifies all tests using the Objective-C-based APIs, and then asserts that all of those tests have been declared on Linux.

This will generate error messages like this if a developer forgets to add a Linux declaration for a newly added test:
<img width="444" alt="Screen Shot 2019-11-28 at 11 47 33" src="https://user-images.githubusercontent.com/2466701/69800401-77923c00-11d5-11ea-885a-216b00a22603.png">