### PR TITLE
HTML: Treat comments as self-closing tags

### DIFF
--- a/Sources/Ink/Internal/HTML.swift
+++ b/Sources/Ink/Internal/HTML.swift
@@ -74,7 +74,7 @@ private extension Reader {
                     return (name.dropLast(), true)
                 }
 
-                return (name, suffix.last == "/")
+                return (name, suffix.last == "/" || name == "!--")
             }
 
             advanceIndex()

--- a/Tests/InkTests/HTMLTests.swift
+++ b/Tests/InkTests/HTMLTests.swift
@@ -93,6 +93,16 @@ final class HTMLTests: XCTestCase {
 
         XCTAssertEqual(html, "<p>Hello</p><br/><p>World</p>")
     }
+
+    func testHTMLComment() {
+        let html = MarkdownParser().html(from: """
+        Hello
+        <!-- Comment -->
+        World
+        """)
+
+        XCTAssertEqual(html, "<p>Hello</p><!-- Comment --><p>World</p>")
+    }
 }
 
 extension HTMLTests {
@@ -107,7 +117,8 @@ extension HTMLTests {
             ("testInlineParagraphTagEndingCurrentParagraph", testInlineParagraphTagEndingCurrentParagraph),
             ("testTopLevelSelfClosingHTMLElement", testTopLevelSelfClosingHTMLElement),
             ("testInlineSelfClosingHTMLElement", testInlineSelfClosingHTMLElement),
-            ("testTopLevelHTMLLineBreak", testTopLevelHTMLLineBreak)
+            ("testTopLevelHTMLLineBreak", testTopLevelHTMLLineBreak),
+            ("testHTMLComment", testHTMLComment)
         ]
     }
 }


### PR DESCRIPTION
This patch makes Ink parse HTML comments correctly, by treating them as self-closing tags, rather than as opening ones (which would cause all subsequent text to be parsed as plain HTML).

Fixes #3