### PR TITLE
Headings: Trim trailing markers

### DIFF
--- a/Sources/Ink/Internal/Heading.swift
+++ b/Sources/Ink/Internal/Heading.swift
@@ -21,7 +21,21 @@ internal struct Heading: Fragment {
 
     func html(usingURLs urls: NamedURLCollection,
               modifiers: ModifierCollection) -> String {
-        let body = text.html(usingURLs: urls, modifiers: modifiers)
+        var body = text.html(usingURLs: urls, modifiers: modifiers)
+
+        if !body.isEmpty {
+            let lastCharacterIndex = body.index(before: body.endIndex)
+            var trimIndex = lastCharacterIndex
+
+            while body[trimIndex] == "#", trimIndex != body.startIndex {
+                trimIndex = body.index(before: trimIndex)
+            }
+
+            if trimIndex != lastCharacterIndex {
+                body = String(body[..<trimIndex])
+            }
+        }
+
         let tagName = "h\(level)"
         return "<\(tagName)>\(body)</\(tagName)>"
     }

--- a/Tests/InkTests/HeadingTests.swift
+++ b/Tests/InkTests/HeadingTests.swift
@@ -46,6 +46,18 @@ final class HeadingTests: XCTestCase {
         let html = MarkdownParser().html(from: markdown)
         XCTAssertEqual(html, "<p>\(markdown)</p>")
     }
+
+    func testRemovingTrailingMarkersFromHeading() {
+        let markdown = "# Heading #######"
+        let html = MarkdownParser().html(from: markdown)
+        XCTAssertEqual(html, "<h1>Heading</h1>")
+    }
+
+    func testHeadingWithOnlyTrailingMarkers() {
+        let markdown = "# #######"
+        let html = MarkdownParser().html(from: markdown)
+        XCTAssertEqual(html, "<h1></h1>")
+    }
 }
 
 extension HeadingTests {
@@ -56,7 +68,9 @@ extension HeadingTests {
             ("testHeadingsWithLeadingNumbers", testHeadingsWithLeadingNumbers),
             ("testHeadingWithPreviousWhitespace", testHeadingWithPreviousWhitespace),
             ("testHeadingWithPreviousNewlineAndWhitespace", testHeadingWithPreviousNewlineAndWhitespace),
-            ("testInvalidHeaderLevel", testInvalidHeaderLevel)
+            ("testInvalidHeaderLevel", testInvalidHeaderLevel),
+            ("testRemovingTrailingMarkersFromHeading", testRemovingTrailingMarkersFromHeading),
+            ("testHeadingWithOnlyTrailingMarkers", testHeadingWithOnlyTrailingMarkers)
         ]
     }
 }


### PR DESCRIPTION
This change makes Ink trim all trailing markers from headings, making it consistent with Gruber’s original Markdown implementation.

So `# Heading #######` will be parsed into `<h1>Heading</h1>`.