### PR TITLE
Introduce case-insensitivity for reference link labels

### DIFF
--- a/Sources/Ink/API/MarkdownParser.swift
+++ b/Sources/Ink/API/MarkdownParser.swift
@@ -42,7 +42,7 @@ public struct MarkdownParser {
     public func parse(_ markdown: String) -> Markdown {
         var reader = Reader(string: markdown)
         var fragments = [ParsedFragment]()
-        var urlsByName = [Substring : URL]()
+        var urlsByName = [String : URL]()
         var metadata: Metadata?
 
         while !reader.didReachEnd {

--- a/Sources/Ink/Internal/NamedURLCollection.swift
+++ b/Sources/Ink/Internal/NamedURLCollection.swift
@@ -5,13 +5,13 @@
 */
 
 internal struct NamedURLCollection {
-    private let urlsByName: [Substring : URL]
+    private let urlsByName: [String : URL]
 
-    init(urlsByName: [Substring : URL]) {
+    init(urlsByName: [String : URL]) {
         self.urlsByName = urlsByName
     }
 
     func url(named name: Substring) -> URL? {
-        urlsByName[name]
+        urlsByName[name.lowercased()]
     }
 }

--- a/Sources/Ink/Internal/URLDeclaration.swift
+++ b/Sources/Ink/Internal/URLDeclaration.swift
@@ -5,12 +5,12 @@
 */
 
 internal struct URLDeclaration: Readable {
-    var name: Substring
+    var name: String
     var url: URL
 
     static func read(using reader: inout Reader) throws -> Self {
         try reader.read("[")
-        let name = try reader.read(until: "]")
+        let name = try reader.read(until: "]").lowercased()
         try reader.read(":")
         try reader.readWhitespaces()
         let url = reader.readUntilEndOfLine()

--- a/Sources/Ink/Internal/URLDeclaration.swift
+++ b/Sources/Ink/Internal/URLDeclaration.swift
@@ -10,11 +10,11 @@ internal struct URLDeclaration: Readable {
 
     static func read(using reader: inout Reader) throws -> Self {
         try reader.read("[")
-        let name = try reader.read(until: "]").lowercased()
+        let name = try reader.read(until: "]")
         try reader.read(":")
         try reader.readWhitespaces()
         let url = reader.readUntilEndOfLine()
 
-        return URLDeclaration(name: name, url: url)
+        return URLDeclaration(name: name.lowercased(), url: url)
     }
 }

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -23,6 +23,18 @@ final class LinkTests: XCTestCase {
         XCTAssertEqual(html, #"<p><a href="swiftbysundell.com">Title</a></p>"#)
     }
 
+    func testCaseMismatchedLinkWithReference() {
+        let html = MarkdownParser().html(from: """
+        [Title][Foo]
+        [Title][αγω]
+
+        [FOO]: /url
+        [ΑΓΩ]: /φου
+        """)
+
+        XCTAssertEqual(html, #"<p><a href="/url">Title</a> <a href="/φου">Title</a></p>"#)
+    }
+
     func testNumericLinkWithReference() {
         let html = MarkdownParser().html(from: """
         [1][1]
@@ -59,6 +71,7 @@ extension LinkTests {
         return [
             ("testLinkWithURL", testLinkWithURL),
             ("testLinkWithReference", testLinkWithReference),
+            ("testCaseMismatchedLinkWithReference", testCaseMismatchedLinkWithReference),
             ("testNumericLinkWithReference", testNumericLinkWithReference),
             ("testBoldLinkWithInternalMarkers", testBoldLinkWithInternalMarkers),
             ("testBoldLinkWithExternalMarkers", testBoldLinkWithExternalMarkers),


### PR DESCRIPTION
This introduces case-insensitivity, per the [CommonMark spec](https://spec.commonmark.org/0.29/#matches):

>One label matches another just in case their normalized forms are equal. To normalize a label, strip off the opening and closing brackets, __perform the Unicode case fold__, strip leading and trailing whitespace and collapse consecutive internal whitespace to a single space. If there are multiple matching reference link definitions, the one that comes first in the document is used. (It is desirable in such cases to emit a warning.)

To achieve this, the label is stored as a `String` (not a `Substring` anymore) that has been `.lowercased()` and lookups are `.lowercased()` before being applied.