### PR TITLE
Disabled hard line breaks being detected (`\`) within headers

### DIFF
--- a/Sources/Ink/Internal/FormattedText.swift
+++ b/Sources/Ink/Internal/FormattedText.swift
@@ -172,7 +172,12 @@ private extension FormattedText {
         }
 
         private mutating func parseNonTriggeringCharacter() {
-            if reader.currentCharacter == "\\" && context != .withinBlock {
+            // If the current character is a `\`, then
+            // we have special handling for it. However,
+            // this does *not* apply at the end of the line
+            // within block contexts.
+            let isEndOfLine = reader.nextCharacter?.isNewline ?? true
+            if reader.currentCharacter == "\\" && !(context == .withinBlock && isEndOfLine) {
                 addPendingTextIfNeeded()
                 skipCharacter()
                 return

--- a/Sources/Ink/Internal/Heading.swift
+++ b/Sources/Ink/Internal/Heading.swift
@@ -14,7 +14,7 @@ internal struct Heading: Fragment {
         let level = reader.readCount(of: "#")
         try require(level > 0 && level < 7)
         try reader.readWhitespaces()
-        let text = FormattedText.read(using: &reader, terminator: "\n")
+        let text = FormattedText.read(using: &reader, terminator: "\n", context: .withinBlock)
 
         return Heading(level: level, text: text)
     }

--- a/Tests/InkTests/HeadingTests.swift
+++ b/Tests/InkTests/HeadingTests.swift
@@ -58,6 +58,14 @@ final class HeadingTests: XCTestCase {
         let html = MarkdownParser().html(from: markdown)
         XCTAssertEqual(html, "<h1></h1>")
     }
+
+    func testHeadingWithHardLineBreak() {
+        let markdown = """
+        ### foo\\
+        """
+        let html = MarkdownParser().html(from: markdown)
+        XCTAssertEqual(html, "<h3>foo\\</h3>")
+    }
 }
 
 extension HeadingTests {
@@ -70,7 +78,8 @@ extension HeadingTests {
             ("testHeadingWithPreviousNewlineAndWhitespace", testHeadingWithPreviousNewlineAndWhitespace),
             ("testInvalidHeaderLevel", testInvalidHeaderLevel),
             ("testRemovingTrailingMarkersFromHeading", testRemovingTrailingMarkersFromHeading),
-            ("testHeadingWithOnlyTrailingMarkers", testHeadingWithOnlyTrailingMarkers)
+            ("testHeadingWithOnlyTrailingMarkers", testHeadingWithOnlyTrailingMarkers),
+            ("testHeadingWithHardLineBreak", testHeadingWithHardLineBreak)
         ]
     }
 }

--- a/Tests/InkTests/HeadingTests.swift
+++ b/Tests/InkTests/HeadingTests.swift
@@ -61,7 +61,7 @@ final class HeadingTests: XCTestCase {
 
     func testHeadingWithHardLineBreak() {
         let markdown = """
-        ### Heading\\
+        ### \\Heading\\
         """
         let html = MarkdownParser().html(from: markdown)
         XCTAssertEqual(html, "<h3>Heading\\</h3>")

--- a/Tests/InkTests/HeadingTests.swift
+++ b/Tests/InkTests/HeadingTests.swift
@@ -61,10 +61,10 @@ final class HeadingTests: XCTestCase {
 
     func testHeadingWithHardLineBreak() {
         let markdown = """
-        ### foo\\
+        ### Heading\\
         """
         let html = MarkdownParser().html(from: markdown)
-        XCTAssertEqual(html, "<h3>foo\\</h3>")
+        XCTAssertEqual(html, "<h3>Heading\\</h3>")
     }
 }
 


### PR DESCRIPTION
I've got another one with the goal of meeting this requirement in [the spec](https://spec.commonmark.org/0.29/#example-643):

```md
### foo\
```
translating to
```html
<h3>foo\</h3>
```

However, I'd like your opinion on the way I let the `FormattedText` parser know to skip checking for `\`. Ideally this parameter would be used more in the future to provide these types of context information to the object but before doing anything too drastic I wanted to get your opinion on this design (in principle–names can be changed of course).