### PR TITLE
Introduced double-space hard line break

### DIFF
--- a/Sources/Ink/Internal/FormattedText.swift
+++ b/Sources/Ink/Internal/FormattedText.swift
@@ -30,7 +30,7 @@ internal struct FormattedText: Readable, HTMLConvertible {
         return components.reduce(into: "") { string, component in
             switch component {
             case .linebreak:
-                string.append("<br />")
+                string.append("<br/>")
             case .text(let text):
                 string.append(String(text))
             case .styleMarker(let marker):
@@ -77,9 +77,8 @@ private extension FormattedText {
         }
 
         mutating func parse() {
-            /// For the purpose of hard line break parsing, indicates
-            /// whether the previous two characters were spaces.
-            var twoSpaceSequence = false
+            var sequentialSpaceCount = 0
+
             while !reader.didReachEnd {
                 do {
                     if let terminator = terminator {
@@ -95,7 +94,7 @@ private extension FormattedText {
                             break
                         }
 
-                        guard reader.previousCharacter != "\\" && !twoSpaceSequence else {
+                        guard reader.previousCharacter != "\\" && !(sequentialSpaceCount >= 2) else {
                             text.components.append(.linebreak)
                             skipCharacter()
                             continue
@@ -113,8 +112,11 @@ private extension FormattedText {
                         continue
                     }
 
-                    twoSpaceSequence = reader.previousCharacter == " "
-                        && reader.currentCharacter == " "
+                    if reader.currentCharacter == " " {
+                        sequentialSpaceCount += 1
+                    } else {
+                        sequentialSpaceCount = 0
+                    }
 
                     if reader.currentCharacter.isSameLineWhitespace {
                         guard let nextCharacter = reader.nextCharacter else {

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -140,7 +140,13 @@ final class TextFormattingTests: XCTestCase {
     func testDoubleSpacedHardLinebreak() {
         let html = MarkdownParser().html(from: "Line 1  \nLine 2")
 
-        XCTAssertEqual(html, "<p>Line 1<br />Line 2</p>")
+        XCTAssertEqual(html, "<p>Line 1<br/>Line 2</p>")
+    }
+
+    func testEscapedHardLinebreak() {
+        let html = MarkdownParser().html(from: "Line 1\\\nLine 2")
+
+        XCTAssertEqual(html, "<p>Line 1<br/>Line 2</p>")
     }
 }
 
@@ -171,7 +177,8 @@ extension TextFormattingTests {
             ("testSingleLineBlockquote", testSingleLineBlockquote),
             ("testMultiLineBlockquote", testMultiLineBlockquote),
             ("testEscapingSymbolsWithBackslash", testEscapingSymbolsWithBackslash),
-            ("testDoubleSpacedHardLinebreak", testDoubleSpacedHardLinebreak)
+            ("testDoubleSpacedHardLinebreak", testDoubleSpacedHardLinebreak),
+            ("testEscapedHardLinebreak", testEscapedHardLinebreak)
         ]
     }
 }

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -136,6 +136,12 @@ final class TextFormattingTests: XCTestCase {
 
         XCTAssertEqual(html, "<p># Not a title *Not italic*</p>")
     }
+
+    func testDoubleSpacedHardLinebreak() {
+        let html = MarkdownParser().html(from: "Line 1  \nLine 2")
+
+        XCTAssertEqual(html, "<p>Line 1<br />Line 2</p>")
+    }
 }
 
 extension TextFormattingTests {
@@ -164,7 +170,8 @@ extension TextFormattingTests {
             ("testEncodingSpecialCharacters", testEncodingSpecialCharacters),
             ("testSingleLineBlockquote", testSingleLineBlockquote),
             ("testMultiLineBlockquote", testMultiLineBlockquote),
-            ("testEscapingSymbolsWithBackslash", testEscapingSymbolsWithBackslash)
+            ("testEscapingSymbolsWithBackslash", testEscapingSymbolsWithBackslash),
+            ("testDoubleSpacedHardLinebreak", testDoubleSpacedHardLinebreak)
         ]
     }
 }


### PR DESCRIPTION
This introduces the [ability to add two spaces at the end of a line and have it treated as a `<br />` element](https://spec.commonmark.org/0.29/#example-630).