### PR TITLE
Small (nitpicky) command line tool fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ For more information on how to use the Swift Package Manager, check out [this ar
 
 ## Command line tool
 
-Ink also ships with a simple but useful command line tool that enables you to use it to convert Markdown to HTML directly from the command line.
+Ink also ships with a simple but useful command line tool that lets you convert Markdown to HTML directly from the command line.
 
 To install it, clone the project and run `make`:
 
@@ -121,27 +121,27 @@ $ cd Ink
 $ make
 ```
 
-The command line tool will be installed as `ink`, and can be passed Markdown text for conversion into HTML several ways.
+The command line tool will be installed as `ink`, and can be passed Markdown text for conversion into HTML in several ways.
 
-Calling without arguments will start reading from stdin until terminated with Ctrl+D
+Calling it without arguments will start reading from `stdin` until terminated with `Ctrl+D`:
 
 ```
 $ ink
 ```
 
-Markdown text can be piped in when called without arguments:
+Markdown text can be piped in when `ink` is called without arguments:
 
 ```
 $ echo "*Hello World*" | ink
 ```
 
-A single argument is treated as a filename, whose contents are parsed:
+A single argument is treated as a filename, and the corresponding file will be parsed:
 
 ```
 $ ink file.md
 ```
 
-A Markdown string can be passed directly using the -m flag:
+A Markdown string can be passed directly using the `-m` or `--markdown` flag:
 
 ```
 $ ink -m "*Hello World*"

--- a/Sources/InkCLI/Printing.swift
+++ b/Sources/InkCLI/Printing.swift
@@ -6,14 +6,22 @@
 
 import Foundation
 
-internal var usageMessage: String = """
+internal func printError(_ error: CustomStringConvertible) {
+    fputs("\(error)\n", stderr)
+}
+
+internal func printUsageMessage() {
+    printError(usageMessage)
+}
+
+private let usageMessage = """
 Usage:  ink [file | -m markdown]
 Options:
   --markdown, -m    Parse a markdown string directly
   --help, -h        Print usage information
 """
 
-internal var helpMessage: String = """
+internal let helpMessage = """
 Ink: Markdown -> HTML converter
 -------------------------------
 \(usageMessage)
@@ -26,7 +34,3 @@ specified path will be used as input. If
 called with the -m option, the following
 argument will be parsed as a Markdown string.
 """
-
-internal func printError(_ error: CustomStringConvertible) {
-    fputs("\(error)\n", stderr)
-}

--- a/Sources/InkCLI/main.swift
+++ b/Sources/InkCLI/main.swift
@@ -18,45 +18,43 @@ let markdown: String
 
 switch arguments.count {
 case 1:
-    // no arguments, parse stdin
+    // No arguments, parse stdin
     markdown = AnyIterator { readLine() }.joined(separator: "\n")
 case let count where arguments[1] == "-m" || arguments[1] == "--markdown":
-    // first argument -m or --markdown, parse Markdown string
+    // First argument is -m or --markdown, parse Markdown string
     guard count == 3 else {
         printError("-m, --markdown flag takes a single following argument")
-        printError(usageMessage)
+        printUsageMessage()
         exit(1)
     }
     markdown = arguments[2]
 case 2:
-    // single argument, parse contents of file
-    let fileUrl: URL
+    // Single argument, parse contents of file
+    let fileURL: URL
 
     switch arguments[1] {
     case let argument where argument.hasPrefix("/"):
-        fileUrl = URL(fileURLWithPath: argument, isDirectory: false)
+        fileURL = URL(fileURLWithPath: argument, isDirectory: false)
     case let argument where argument.hasPrefix("~"):
         let absoluteString = NSString(string: argument).expandingTildeInPath
-        fileUrl = URL(fileURLWithPath: absoluteString, isDirectory: false)
+        fileURL = URL(fileURLWithPath: absoluteString, isDirectory: false)
     default:
-        let dir = FileManager.default.currentDirectoryPath
-        let dirUrl = URL(fileURLWithPath: dir, isDirectory: true)
-        fileUrl = dirUrl.appendingPathComponent(arguments[1])
+        let directory = FileManager.default.currentDirectoryPath
+        let directoryURL = URL(fileURLWithPath: directory, isDirectory: true)
+        fileURL = directoryURL.appendingPathComponent(arguments[1])
     }
 
     do {
-        // this is 5x faster than 'markdown = try String(contentsOf: fileUrl, encoding: .utf8)'
-        let data = try Data(contentsOf: fileUrl)
+        let data = try Data(contentsOf: fileURL)
         markdown = String(decoding: data, as: UTF8.self)
     } catch {
         printError(error.localizedDescription)
-        printError(usageMessage)
+        printUsageMessage()
         exit(1)
     }
 default:
-    // incorrect number of arguments
     printError("Too many arguments")
-    printError(usageMessage)
+    printUsageMessage()
     exit(1)
 }
 


### PR DESCRIPTION
- README improvements for CLI usage.
- Make `usageMessage` private and add a function for printing it.
- Use `let` for constants.
- Slightly tweaked comment and variable wording.