### PR TITLE
Horizontal Rule to pure HTML5

### DIFF
--- a/Sources/Ink/Internal/HorizontalLine.swift
+++ b/Sources/Ink/Internal/HorizontalLine.swift
@@ -19,6 +19,6 @@ internal struct HorizontalLine: Fragment {
 
     func html(usingURLs urls: NamedURLCollection,
               modifiers: ModifierCollection) -> String {
-        return "<hr/>"
+        return "<hr>"
     }
 }

--- a/Tests/InkTests/HorizontalLineTests.swift
+++ b/Tests/InkTests/HorizontalLineTests.swift
@@ -17,12 +17,12 @@ final class HorizontalLineTests: XCTestCase {
         World
         """)
 
-        XCTAssertEqual(html, "<p>Hello</p><hr/><p>World</p>")
+        XCTAssertEqual(html, "<p>Hello</p><hr><p>World</p>")
     }
 
     func testHorizontalLineWithDashesAtTheStartOfString() {
         let html = MarkdownParser().html(from: "---\nHello")
-        XCTAssertEqual(html, "<hr/><p>Hello</p>")
+        XCTAssertEqual(html, "<hr><p>Hello</p>")
     }
 
     func testHorizontalLineWithAsterisks() {
@@ -34,7 +34,7 @@ final class HorizontalLineTests: XCTestCase {
         World
         """)
 
-        XCTAssertEqual(html, "<p>Hello</p><hr/><p>World</p>")
+        XCTAssertEqual(html, "<p>Hello</p><hr><p>World</p>")
     }
 }
 


### PR DESCRIPTION
While working on conformance I realized that proper minimized versions of the Horizontal Line should be \<hr>

If the XML form is desired then perhaps a Modifier could be built.