### PR TITLE
Break without slash <br>

### DIFF
--- a/Sources/Ink/Internal/FormattedText.swift
+++ b/Sources/Ink/Internal/FormattedText.swift
@@ -30,7 +30,7 @@ internal struct FormattedText: Readable, HTMLConvertible {
         return components.reduce(into: "") { string, component in
             switch component {
             case .linebreak:
-                string.append("<br/>")
+                string.append("<br>")
             case .text(let text):
                 string.append(String(text))
             case .styleMarker(let marker):

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -140,13 +140,13 @@ final class TextFormattingTests: XCTestCase {
     func testDoubleSpacedHardLinebreak() {
         let html = MarkdownParser().html(from: "Line 1  \nLine 2")
 
-        XCTAssertEqual(html, "<p>Line 1<br/>Line 2</p>")
+        XCTAssertEqual(html, "<p>Line 1<br>Line 2</p>")
     }
 
     func testEscapedHardLinebreak() {
         let html = MarkdownParser().html(from: "Line 1\\\nLine 2")
 
-        XCTAssertEqual(html, "<p>Line 1<br/>Line 2</p>")
+        XCTAssertEqual(html, "<p>Line 1<br>Line 2</p>")
     }
 }
 


### PR DESCRIPTION
I checked the normalization rules at CommonMark and they do normalize break and horizontal rule.