### PR TITLE
Parser: Ignore escaped terminator

### DIFF
--- a/Sources/Ink/Internal/FormattedText.swift
+++ b/Sources/Ink/Internal/FormattedText.swift
@@ -76,7 +76,7 @@ private extension FormattedText {
         mutating func parse() {
             while !reader.didReachEnd {
                 do {
-                    if let terminator = terminator {
+                    if let terminator = terminator, reader.previousCharacter != "\\" {
                         guard reader.currentCharacter != terminator else {
                             break
                         }

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -47,6 +47,12 @@ final class LinkTests: XCTestCase {
         let html = MarkdownParser().html(from: "[He_llo](/he_llo)")
         XCTAssertEqual(html, "<p><a href=\"/he_llo\">He_llo</a></p>")
     }
+    
+    func testLinkWithEscapedSquareBrackets() {
+        let html = MarkdownParser().html(from: "[\\[Hello\\]](hello)")
+
+        XCTAssertEqual(html, #"<p><a href="hello">[Hello]</a></p>"#)
+    }
 }
 
 extension LinkTests {
@@ -57,7 +63,8 @@ extension LinkTests {
             ("testNumericLinkWithReference", testNumericLinkWithReference),
             ("testBoldLinkWithInternalMarkers", testBoldLinkWithInternalMarkers),
             ("testBoldLinkWithExternalMarkers", testBoldLinkWithExternalMarkers),
-            ("testLinkWithUnderscores", testLinkWithUnderscores)
+            ("testLinkWithUnderscores", testLinkWithUnderscores),
+            ("testLinkWithEscapedSquareBrackets", testLinkWithEscapedSquareBrackets)
         ]
     }
 }


### PR DESCRIPTION
The Parser no longer breaks when it encounters an escaped terminator. This would previously prevent links with escaped square brackets from being converted correctly. I added a test to check for this case.