### PR TITLE
Parser: Ignore escaped terminator

### DIFF
--- a/Sources/Ink/Internal/FormattedText.swift
+++ b/Sources/Ink/Internal/FormattedText.swift
@@ -81,7 +81,7 @@ private extension FormattedText {
 
             while !reader.didReachEnd {
                 do {
-                    if let terminator = terminator {
+                    if let terminator = terminator, reader.previousCharacter != "\\" {
                         guard reader.currentCharacter != terminator else {
                             break
                         }

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -64,6 +64,11 @@ final class LinkTests: XCTestCase {
         let html = MarkdownParser().html(from: "[Hello]")
         XCTAssertEqual(html, "<p>[Hello]</p>")
     }
+    
+    func testLinkWithEscapedSquareBrackets() {
+        let html = MarkdownParser().html(from: "[\\[Hello\\]](hello)")
+        XCTAssertEqual(html, #"<p><a href="hello">[Hello]</a></p>"#)
+    }
 }
 
 extension LinkTests {
@@ -76,7 +81,8 @@ extension LinkTests {
             ("testBoldLinkWithInternalMarkers", testBoldLinkWithInternalMarkers),
             ("testBoldLinkWithExternalMarkers", testBoldLinkWithExternalMarkers),
             ("testLinkWithUnderscores", testLinkWithUnderscores),
-            ("testUnterminatedLink", testUnterminatedLink)
+            ("testUnterminatedLink", testUnterminatedLink),
+            ("testLinkWithEscapedSquareBrackets", testLinkWithEscapedSquareBrackets)
         ]
     }
 }


### PR DESCRIPTION
The Parser no longer breaks when it encounters an escaped terminator. This would previously prevent links with escaped square brackets from being converted correctly. I added a test to check for this case.