### PR TITLE
Backslash escapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Ink supports the following Markdown features:
 - Bold text, by surrounding a piece of text with either two asterisks (`**`), or two underscores (`__`). For example `**Bold text**`.
 - Text strikethrough, by surrounding a piece of text with two tildes (`~~`), for example `~~Strikethrough text~~`.
 - Inline code, marked with a backtick on either site of the code.
-- Code blocks, marked with three or more backticks both above and below the block.
+- Code blocks, marked with three or more backticks, or three or more tildes (`~~~`), both above and below the block.
 - Links, using the following syntax: `[Title](url)`.
 - Images, using the following syntax: `![Alt text](image-url)`.
 - Both images and links can also use reference URLs, which can be defined anywhere in a Markdown document using this syntax: `[referenceName]: url`.

--- a/Sources/Ink/API/MarkdownParser.swift
+++ b/Sources/Ink/API/MarkdownParser.swift
@@ -123,6 +123,7 @@ private extension MarkdownParser {
         case "<": return HTML.self
         case ">": return Blockquote.self
         case "`": return CodeBlock.self
+        case "~": return CodeBlock.self
         case "-" where character == nextCharacter,
              "*" where character == nextCharacter:
             return HorizontalLine.self

--- a/Sources/Ink/Internal/Character+Escaping.swift
+++ b/Sources/Ink/Internal/Character+Escaping.swift
@@ -3,10 +3,9 @@
 *  Copyright (c) John Sundell 2019
 *  MIT license, see LICENSE file for details
 */
-// ASCII chars escapable from CommonMark spec
-// \!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~
-// Result desired
-// !&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\]^_`{|}~
+// This escape list seems archaic but is necessary because the backslash remains
+// if used on a character that is not a deemed ASCII punctuation symbol.
+// https://spec.commonmark.org/0.29/#characters-and-lines
 // An ASCII punctuation character is !, ", #, $, %, &, ', (, ), *, +, ,, -, .,/
 // (U+0021–2F), :, ;, <, =, >, ?, @ (U+003A–0040), [, \, ], ^, _,`
 // (U+005B–0060), {, |, }, or ~ (U+007B–007E).
@@ -44,45 +43,10 @@ let escapeSubstitutions: [Character: String] = [
     "&": "&amp;",
     "\"": "&quot;",
     Character(Unicode.Scalar(0000)): String(Unicode.Scalar(UInt32(0xFFFD))!),
-    //Took some research to initialize this one. Security of null char replaced so it cannot be used to cause end of file/string problems somewhere else. I don't think this is easy to test?
-    Character(Unicode.Scalar(UInt32(0x0021))): String(Unicode.Scalar(UInt32(0x0021))!),
-    Character(Unicode.Scalar(UInt32(0x0022))): String(Unicode.Scalar(UInt32(0x0022))!),
-    Character(Unicode.Scalar(UInt32(0x0023))): String(Unicode.Scalar(UInt32(0x0023))!),
-    Character(Unicode.Scalar(UInt32(0x0024))): String(Unicode.Scalar(UInt32(0x0024))!),
-    Character(Unicode.Scalar(UInt32(0x0025))): String(Unicode.Scalar(UInt32(0x0025))!),
-    Character(Unicode.Scalar(UInt32(0x0026))): String(Unicode.Scalar(UInt32(0x0026))!),
-    Character(Unicode.Scalar(UInt32(0x0027))): String(Unicode.Scalar(UInt32(0x0027))!),
-    Character(Unicode.Scalar(UInt32(0x0028))): String(Unicode.Scalar(UInt32(0x0028))!),
-    Character(Unicode.Scalar(UInt32(0x0029))): String(Unicode.Scalar(UInt32(0x0029))!),
-    Character(Unicode.Scalar(UInt32(0x002A))): String(Unicode.Scalar(UInt32(0x002A))!),
-    Character(Unicode.Scalar(UInt32(0x002B))): String(Unicode.Scalar(UInt32(0x002B))!),
-    Character(Unicode.Scalar(UInt32(0x002C))): String(Unicode.Scalar(UInt32(0x002C))!),
-    Character(Unicode.Scalar(UInt32(0x002D))): String(Unicode.Scalar(UInt32(0x002D))!),
-    Character(Unicode.Scalar(UInt32(0x002E))): String(Unicode.Scalar(UInt32(0x002E))!),
-    Character(Unicode.Scalar(UInt32(0x002F))): String(Unicode.Scalar(UInt32(0x002F))!),
-    Character(Unicode.Scalar(UInt32(0x005B))): String(Unicode.Scalar(UInt32(0x005B))!),
-    Character(Unicode.Scalar(UInt32(0x005C))): String(Unicode.Scalar(UInt32(0x005C))!),
-    Character(Unicode.Scalar(UInt32(0x005D))): String(Unicode.Scalar(UInt32(0x005D))!),
-    Character(Unicode.Scalar(UInt32(0x005E))): String(Unicode.Scalar(UInt32(0x005E))!),
-    Character(Unicode.Scalar(UInt32(0x005F))): String(Unicode.Scalar(UInt32(0x005F))!),
-    Character(Unicode.Scalar(UInt32(0x0060))): String(Unicode.Scalar(UInt32(0x0060))!),
-    Character(Unicode.Scalar(UInt32(0x007B))): String(Unicode.Scalar(UInt32(0x007B))!),
-    Character(Unicode.Scalar(UInt32(0x007C))): String(Unicode.Scalar(UInt32(0x007C))!),
-    Character(Unicode.Scalar(UInt32(0x007D))): String(Unicode.Scalar(UInt32(0x007D))!),
-    Character(Unicode.Scalar(UInt32(0x007E))): String(Unicode.Scalar(UInt32(0x007E))!),
+    // Took some research to initialize this one. For security the null char replaced
+    // so it cannot be used to cause end of file/string problems somewhere else.
+    // I don't think this is easy to test?
+    // https://spec.commonmark.org/0.29/#insecure-characters
     ]
 
 func escaped(_ char: Character) -> String? { escapeSubstitutions[char] }
-
-
-internal extension Character {
-    @available(*, deprecated, message: "use escaped(_ char: Character) -> String?")
-    var escaped: String? {
-        switch self {
-        case ">": return "&gt;"
-        case "<": return "&lt;"
-        case "&": return "&amp;"
-        default: return nil
-        }
-    }
-}

--- a/Sources/Ink/Internal/Character+Escaping.swift
+++ b/Sources/Ink/Internal/Character+Escaping.swift
@@ -7,6 +7,9 @@
 // \!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~
 // Result desired
 // !&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\]^_`{|}~
+// An ASCII punctuation character is !, ", #, $, %, &, ', (, ), *, +, ,, -, .,/
+// (U+0021–2F), :, ;, <, =, >, ?, @ (U+003A–0040), [, \, ], ^, _,`
+// (U+005B–0060), {, |, }, or ~ (U+007B–007E).
 let escapeSubstitutions: [Character: String] = [
     "!": "!",
     "#": "#",
@@ -39,7 +42,34 @@ let escapeSubstitutions: [Character: String] = [
     ">": "&gt;",
     "<": "&lt;",
     "&": "&amp;",
-    "\"": "&quot;"
+    "\"": "&quot;",
+    Character(Unicode.Scalar(0000)): String(Unicode.Scalar(UInt32(0xFFFD))!),
+    //Took some research to initialize this one. Security of null char replaced so it cannot be used to cause end of file/string problems somewhere else. I don't think this is easy to test?
+    Character(Unicode.Scalar(UInt32(0x0021))): String(Unicode.Scalar(UInt32(0x0021))!),
+    Character(Unicode.Scalar(UInt32(0x0022))): String(Unicode.Scalar(UInt32(0x0022))!),
+    Character(Unicode.Scalar(UInt32(0x0023))): String(Unicode.Scalar(UInt32(0x0023))!),
+    Character(Unicode.Scalar(UInt32(0x0024))): String(Unicode.Scalar(UInt32(0x0024))!),
+    Character(Unicode.Scalar(UInt32(0x0025))): String(Unicode.Scalar(UInt32(0x0025))!),
+    Character(Unicode.Scalar(UInt32(0x0026))): String(Unicode.Scalar(UInt32(0x0026))!),
+    Character(Unicode.Scalar(UInt32(0x0027))): String(Unicode.Scalar(UInt32(0x0027))!),
+    Character(Unicode.Scalar(UInt32(0x0028))): String(Unicode.Scalar(UInt32(0x0028))!),
+    Character(Unicode.Scalar(UInt32(0x0029))): String(Unicode.Scalar(UInt32(0x0029))!),
+    Character(Unicode.Scalar(UInt32(0x002A))): String(Unicode.Scalar(UInt32(0x002A))!),
+    Character(Unicode.Scalar(UInt32(0x002B))): String(Unicode.Scalar(UInt32(0x002B))!),
+    Character(Unicode.Scalar(UInt32(0x002C))): String(Unicode.Scalar(UInt32(0x002C))!),
+    Character(Unicode.Scalar(UInt32(0x002D))): String(Unicode.Scalar(UInt32(0x002D))!),
+    Character(Unicode.Scalar(UInt32(0x002E))): String(Unicode.Scalar(UInt32(0x002E))!),
+    Character(Unicode.Scalar(UInt32(0x002F))): String(Unicode.Scalar(UInt32(0x002F))!),
+    Character(Unicode.Scalar(UInt32(0x005B))): String(Unicode.Scalar(UInt32(0x005B))!),
+    Character(Unicode.Scalar(UInt32(0x005C))): String(Unicode.Scalar(UInt32(0x005C))!),
+    Character(Unicode.Scalar(UInt32(0x005D))): String(Unicode.Scalar(UInt32(0x005D))!),
+    Character(Unicode.Scalar(UInt32(0x005E))): String(Unicode.Scalar(UInt32(0x005E))!),
+    Character(Unicode.Scalar(UInt32(0x005F))): String(Unicode.Scalar(UInt32(0x005F))!),
+    Character(Unicode.Scalar(UInt32(0x0060))): String(Unicode.Scalar(UInt32(0x0060))!),
+    Character(Unicode.Scalar(UInt32(0x007B))): String(Unicode.Scalar(UInt32(0x007B))!),
+    Character(Unicode.Scalar(UInt32(0x007C))): String(Unicode.Scalar(UInt32(0x007C))!),
+    Character(Unicode.Scalar(UInt32(0x007D))): String(Unicode.Scalar(UInt32(0x007D))!),
+    Character(Unicode.Scalar(UInt32(0x007E))): String(Unicode.Scalar(UInt32(0x007E))!),
     ]
 
 func escaped(_ char: Character) -> String? { escapeSubstitutions[char] }

--- a/Sources/Ink/Internal/Character+Escaping.swift
+++ b/Sources/Ink/Internal/Character+Escaping.swift
@@ -3,6 +3,19 @@
 *  Copyright (c) John Sundell 2019
 *  MIT license, see LICENSE file for details
 */
+
+// first are the escapes used to make safe the HTML. Added here is the null character substitution for security.
+let escapeSubstitutionsForHTML: [Character: String] = [
+">": "&gt;",
+"<": "&lt;",
+"&": "&amp;",
+"\"": "&quot;",
+Character(Unicode.Scalar(0000)): String(Unicode.Scalar(UInt32(0xFFFD))!)
+// Took some research to initialize this one. For security the null char replaced
+// so it cannot be used to cause end of file/string problems somewhere else.
+// I don't think this is easy to test?
+// https://spec.commonmark.org/0.29/#insecure-characters
+]
 // This escape list seems archaic but is necessary because the backslash remains
 // if used on a character that is not a deemed ASCII punctuation symbol.
 // https://spec.commonmark.org/0.29/#characters-and-lines
@@ -50,3 +63,5 @@ let escapeSubstitutions: [Character: String] = [
     ]
 
 func escaped(_ char: Character) -> String? { escapeSubstitutions[char] }
+
+func escapedHtml(_ char: Character) -> String? { escapeSubstitutionsForHTML[char] }

--- a/Sources/Ink/Internal/Character+Escaping.swift
+++ b/Sources/Ink/Internal/Character+Escaping.swift
@@ -39,16 +39,11 @@ let escapeSubstitutions: [Character: String] = [
     ">": "&gt;",
     "<": "&lt;",
     "&": "&amp;",
-    "\"": "&quot;",
-    
-]
+    "\"": "&quot;"
+    ]
 
-func escaped(_ char: Character) -> String? {
-if let substitution = escapeSubstitutions[char] {
-    return substitution
-}
-return nil
-}
+func escaped(_ char: Character) -> String? { escapeSubstitutions[char] }
+
 
 internal extension Character {
     @available(*, deprecated, message: "use escaped(_ char: Character) -> String?")

--- a/Sources/Ink/Internal/Character+Escaping.swift
+++ b/Sources/Ink/Internal/Character+Escaping.swift
@@ -49,40 +49,6 @@ Character(Unicode.Scalar(0000)): String(Unicode.Scalar(UInt32(0xFFFD))!)
 // An ASCII punctuation character is !, ", #, $, %, &, ', (, ), *, +, ,, -, .,/
 // (U+0021–2F), :, ;, <, =, >, ?, @ (U+003A–0040), [, \, ], ^, _,`
 // (U+005B–0060), {, |, }, or ~ (U+007B–007E).
-let escapeSubstitutions: [Character: String] = [
-    "!": "!",
-    "#": "#",
-    "$": "$",
-    "%": "%",
-    "(": "(",
-    ")": ")",
-    "\'": "\'", // "&#34;" maybe here for cross-site scripting security. Needs more investigation
-    "*": "*",
-    "+": "+",
-    ",": ",",
-    "-": "-",
-    ".": ".",
-    "/": "/",
-    "\\": "\\",
-    ":": ":",
-    ";": ";",
-    "=": "=",
-    "?": "?",
-    "@": "@",
-    "[": "[",
-    "]": "]",
-    "^": "^",
-    "_": "_",
-    "`": "`",
-    "{": "{",
-    "}": "}",
-    "|": "|",
-    "~": "~",
-    ">": "&gt;",
-    "<": "&lt;",
-    "&": "&amp;",
-    "\"": "&quot;"
-    ]
 
 // A future performance opportunity is to discover if loading a [Bool]
 // just for low order ASCII is faster than a dictionary.
@@ -92,28 +58,57 @@ let escapeSubstitutionsTruthDict: [Character: Bool] =
     """#####.reduce(into: [:]) {result,char in
     result[char] = true
 }
-/// The escape used to meet the CommonMark spec.
-/// It includes the basic HTML escapes used to make html text and attributes inside double quotes safe.
-/// Also included is the ability to backslash escape the ASCII punctuation characters
+/// Use to meet the CommonMark spec.
+/// to backslash escape the ASCII punctuation characters
+///
 /// An ASCII punctuation character is
+///
 ///  !, ", #, $, %, &, ', (, ), *, +, ,, -, .,/ (U+0021–2F),
+///
 ///  :, ;, <, =, >, ?, @ (U+003A–0040),
+///
 ///  [, \, ], ^, _,`(U+005B–0060),
+///
 ///  {, |, }, or ~ (U+007B–007E).
-///  If nil is returned the character is not needing markdown escaping.
+///
 /// - Parameter char: A single Character
 func escapedASCIIPunctuation(_ char: Character) -> Bool {escapeSubstitutionsTruthDict[char] ?? false}
 
 /// A minimal HTML escape for html text and attributes inside double quotes
 /// If nil is returned the character is not needing html escaping.
+///
+/// ">": "\&gt;",  "<": "\&lt;", "&": "\&amp;", "\"": "\&quot;",
+/// And for security the Null character is substituted.
+/// Character(Unicode.Scalar(0000)): String(Unicode.Scalar(UInt32(0xFFFD))!)
 /// - Parameter char: A single Character
 func escapedMarkdownHTML(_ char: Character) -> String? { escapeSubstitutionsForMarkdown[char] }
+
+/// A minimal HTML escape for html text and attributes inside double quotes
+///
+/// Use on HTML output phase to escape Substrings to output Strings.
+///
+/// /// ">": "\&gt;",  "<": "\&lt;", "&": "\&amp;", "\"": "\&quot;",
+///
+/// And for security the Null character is substituted.
+///
+/// Character(Unicode.Scalar(0000)): String(Unicode.Scalar(UInt32(0xFFFD))!)
+/// - Parameter substring: A substring of the original input usually
 func htmlEscapeASubstring(_ substring: Substring) -> String {
      substring.reduce(into: ""){result,char in
         result.append(contentsOf: escapeSubstitutionsForMarkdown[char] ?? String(char))
     }
 }
 
+/// A minimal HTML escape for html text and attributes inside double quotes
+///
+/// Use on HTML output phase to escape Strings to output Strings.
+///
+/// /// ">": "\&gt;",  "<": "\&lt;", "&": "\&amp;", "\"": "\&quot;",
+///
+/// And for security the Null character is substituted.
+///
+/// Character(Unicode.Scalar(0000)): String(Unicode.Scalar(UInt32(0xFFFD))!)
+/// - Parameter str: The input is already a String
 func htmlEscapeAString(_ str: String) -> String {
      return htmlEscapeASubstring(Substring(str))
     }

--- a/Sources/Ink/Internal/Character+Escaping.swift
+++ b/Sources/Ink/Internal/Character+Escaping.swift
@@ -5,17 +5,33 @@
 */
 
 // first are the escapes used to make safe the HTML. Added here is the null character substitution for security.
-let escapeSubstitutionsForHTML: [Character: String] = [
+let escapeSubstitutionsForMarkdown: [Character: String] = [
 ">": "&gt;",
 "<": "&lt;",
 "&": "&amp;",
-"\"": "&quot;",
+"\"": "&quot;",    // "&#34;" is shorter than "&quot;" but commonmark tests are specifying "&quot;"
+    // "&#39;" is shorter than "&apos;" and apos was not in HTML until HTML5.Commonmark tests are not specifying single quote escape
 Character(Unicode.Scalar(0000)): String(Unicode.Scalar(UInt32(0xFFFD))!)
 // Took some research to initialize this one. For security the null char replaced
 // so it cannot be used to cause end of file/string problems somewhere else.
 // I don't think this is easy to test?
 // https://spec.commonmark.org/0.29/#insecure-characters
 ]
+
+// now are the escapes used to make safe the HTML attribute values that are themselves in quotes. Added here is the null character substitution for security.
+let escapeSubstitutionsForHTMLAttributes: [Character: String] = [
+">": "&gt;",
+"<": "&lt;",
+"&": "&amp;",
+"\"": "&quot;", // "&#34;" is shorter than "&quot;" but commonmark tests are specifying "&quot;"
+"\'": "&#39;",    // "&#39;" is shorter than "&apos;" and apos was not in HTML until HTML5.
+Character(Unicode.Scalar(0000)): String(Unicode.Scalar(UInt32(0xFFFD))!)
+// Took some research to initialize this one. For security the null char replaced
+// so it cannot be used to cause end of file/string problems somewhere else.
+// I don't think this is easy to test?
+// https://spec.commonmark.org/0.29/#insecure-characters
+]
+
 // This escape list seems archaic but is necessary because the backslash remains
 // if used on a character that is not a deemed ASCII punctuation symbol.
 // https://spec.commonmark.org/0.29/#characters-and-lines
@@ -29,7 +45,7 @@ let escapeSubstitutions: [Character: String] = [
     "%": "%",
     "(": "(",
     ")": ")",
-    "\'": "\'",
+    "\'": "\'", // "&#34;" maybe here for cross-site scripting security. Needs more investigation
     "*": "*",
     "+": "+",
     ",": ",",
@@ -64,4 +80,4 @@ let escapeSubstitutions: [Character: String] = [
 
 func escaped(_ char: Character) -> String? { escapeSubstitutions[char] }
 
-func escapedHtml(_ char: Character) -> String? { escapeSubstitutionsForHTML[char] }
+func escapedMarkdownHTML(_ char: Character) -> String? { escapeSubstitutionsForMarkdown[char] }

--- a/Sources/Ink/Internal/Character+Escaping.swift
+++ b/Sources/Ink/Internal/Character+Escaping.swift
@@ -3,14 +3,16 @@
 *  Copyright (c) John Sundell 2019
 *  MIT license, see LICENSE file for details
 */
+// Almost more important than specification compliance is the security of the ultimate website produced. See:
+// https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html
 
 // first are the escapes used to make safe the HTML. Added here is the null character substitution for security.
+// this should be used for general HTML text and inside double-quote attributes.
 let escapeSubstitutionsForMarkdown: [Character: String] = [
 ">": "&gt;",
 "<": "&lt;",
 "&": "&amp;",
-"\"": "&quot;",    // "&#34;" is shorter than "&quot;" but commonmark tests are specifying "&quot;"
-    // "&#39;" is shorter than "&apos;" and apos was not in HTML until HTML5.Commonmark tests are not specifying single quote escape
+"\"": "&quot;",
 Character(Unicode.Scalar(0000)): String(Unicode.Scalar(UInt32(0xFFFD))!)
 // Took some research to initialize this one. For security the null char replaced
 // so it cannot be used to cause end of file/string problems somewhere else.
@@ -18,7 +20,9 @@ Character(Unicode.Scalar(0000)): String(Unicode.Scalar(UInt32(0xFFFD))!)
 // https://spec.commonmark.org/0.29/#insecure-characters
 ]
 
-// now are the escapes used to make safe the HTML attribute values that are themselves in quotes. Added here is the null character substitution for security.
+// now are the escapes used to make safe the HTML attribute values
+// that are themselves in single quotes or double quotes.
+// Added here is the null character substitution for security.
 let escapeSubstitutionsForHTMLAttributes: [Character: String] = [
 ">": "&gt;",
 "<": "&lt;",
@@ -31,6 +35,13 @@ Character(Unicode.Scalar(0000)): String(Unicode.Scalar(UInt32(0xFFFD))!)
 // I don't think this is easy to test?
 // https://spec.commonmark.org/0.29/#insecure-characters
 ]
+
+// For future reference to anyone thinking of escaping text allowed in unquoted attributes. (Very scary and messy)
+// Except for alphanumeric characters, escape all characters with ASCII values less than 256 with the &#xHH;
+// format (or a named entity if available) to prevent switching out of the attribute.
+// The reason this rule is so broad is that developers frequently leave attributes unquoted.
+// Properly quoted attributes can only be escaped with the corresponding quote.
+// Unquoted attributes can be broken out of with many characters, including [space] % * + , - / ; < = > ^ and |.
 
 // This escape list seems archaic but is necessary because the backslash remains
 // if used on a character that is not a deemed ASCII punctuation symbol.
@@ -78,6 +89,19 @@ let escapeSubstitutions: [Character: String] = [
     // https://spec.commonmark.org/0.29/#insecure-characters
     ]
 
+/// The escape used to meet the CommonMark spec.
+/// It includes the basic HTML escapes used to make html text and attributes inside double quotes safe.
+/// Also included is the ability to backslash escape the ASCII punctuation characters
+/// An ASCII punctuation character is
+///  !, ", #, $, %, &, ', (, ), *, +, ,, -, .,/ (U+0021–2F),
+///  :, ;, <, =, >, ?, @ (U+003A–0040),
+///  [, \, ], ^, _,`(U+005B–0060),
+///  {, |, }, or ~ (U+007B–007E).
+///  If nil is returned the character is not needing markdown escaping.
+/// - Parameter char: A single Character
 func escaped(_ char: Character) -> String? { escapeSubstitutions[char] }
 
+/// A minimal HTML escape for html text and attributes inside double quotes
+/// If nil is returned the character is not needing html escaping.
+/// - Parameter char: A single Character
 func escapedMarkdownHTML(_ char: Character) -> String? { escapeSubstitutionsForMarkdown[char] }

--- a/Sources/Ink/Internal/Character+Escaping.swift
+++ b/Sources/Ink/Internal/Character+Escaping.swift
@@ -105,3 +105,12 @@ func escaped(_ char: Character) -> String? { escapeSubstitutions[char] }
 /// If nil is returned the character is not needing html escaping.
 /// - Parameter char: A single Character
 func escapedMarkdownHTML(_ char: Character) -> String? { escapeSubstitutionsForMarkdown[char] }
+func htmlEscapeASubstring(_ substring: Substring) -> String {
+     substring.reduce(into: ""){result,char in
+        result.append(contentsOf: escapeSubstitutionsForMarkdown[char] ?? String(char))
+    }
+}
+
+func htmlEscapeAString(_ str: String) -> String {
+     return htmlEscapeASubstring(Substring(str))
+    }

--- a/Sources/Ink/Internal/Character+Escaping.swift
+++ b/Sources/Ink/Internal/Character+Escaping.swift
@@ -81,14 +81,17 @@ let escapeSubstitutions: [Character: String] = [
     ">": "&gt;",
     "<": "&lt;",
     "&": "&amp;",
-    "\"": "&quot;",
-    Character(Unicode.Scalar(0000)): String(Unicode.Scalar(UInt32(0xFFFD))!),
-    // Took some research to initialize this one. For security the null char replaced
-    // so it cannot be used to cause end of file/string problems somewhere else.
-    // I don't think this is easy to test?
-    // https://spec.commonmark.org/0.29/#insecure-characters
+    "\"": "&quot;"
     ]
 
+// A future performance opportunity is to discover if loading a [Bool]
+// just for low order ASCII is faster than a dictionary.
+let escapeSubstitutionsTruthDict: [Character: Bool] =
+    #####"""
+    !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
+    """#####.reduce(into: [:]) {result,char in
+    result[char] = true
+}
 /// The escape used to meet the CommonMark spec.
 /// It includes the basic HTML escapes used to make html text and attributes inside double quotes safe.
 /// Also included is the ability to backslash escape the ASCII punctuation characters
@@ -99,7 +102,7 @@ let escapeSubstitutions: [Character: String] = [
 ///  {, |, }, or ~ (U+007B–007E).
 ///  If nil is returned the character is not needing markdown escaping.
 /// - Parameter char: A single Character
-func escaped(_ char: Character) -> String? { escapeSubstitutions[char] }
+func escapedASCIIPunctuation(_ char: Character) -> Bool {escapeSubstitutionsTruthDict[char] ?? false}
 
 /// A minimal HTML escape for html text and attributes inside double quotes
 /// If nil is returned the character is not needing html escaping.

--- a/Sources/Ink/Internal/Character+Escaping.swift
+++ b/Sources/Ink/Internal/Character+Escaping.swift
@@ -3,8 +3,55 @@
 *  Copyright (c) John Sundell 2019
 *  MIT license, see LICENSE file for details
 */
+// ASCII chars escapable from CommonMark spec
+// \!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~
+// Result desired
+// !&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\]^_`{|}~
+let escapeSubstitutions: [Character: String] = [
+    "!": "!",
+    "#": "#",
+    "$": "$",
+    "%": "%",
+    "(": "(",
+    ")": ")",
+    "\'": "\'",
+    "*": "*",
+    "+": "+",
+    ",": ",",
+    "-": "-",
+    ".": ".",
+    "/": "/",
+    "\\": "\\",
+    ":": ":",
+    ";": ";",
+    "=": "=",
+    "?": "?",
+    "@": "@",
+    "[": "[",
+    "]": "]",
+    "^": "^",
+    "_": "_",
+    "`": "`",
+    "{": "{",
+    "}": "}",
+    "|": "|",
+    "~": "~",
+    ">": "&gt;",
+    "<": "&lt;",
+    "&": "&amp;",
+    "\"": "&quot;",
+    
+]
+
+func escaped(_ char: Character) -> String? {
+if let substitution = escapeSubstitutions[char] {
+    return substitution
+}
+return nil
+}
 
 internal extension Character {
+    @available(*, deprecated, message: "use escaped(_ char: Character) -> String?")
     var escaped: String? {
         switch self {
         case ">": return "&gt;"

--- a/Sources/Ink/Internal/CodeBlock.swift
+++ b/Sources/Ink/Internal/CodeBlock.swift
@@ -37,7 +37,7 @@ internal struct CodeBlock: Fragment {
                 }
             }
 
-            if let escaped = escapedHtml(reader.currentCharacter) {
+            if let escaped = escapedMarkdownHTML(reader.currentCharacter) {
                 code.append(escaped)
             } else {
                 code.append(reader.currentCharacter)

--- a/Sources/Ink/Internal/CodeBlock.swift
+++ b/Sources/Ink/Internal/CodeBlock.swift
@@ -17,10 +17,12 @@ internal struct CodeBlock: Fragment {
         try require(startingMarkerCount >= 3)
         reader.discardWhitespaces()
 
-        let language = reader
+        let infoString = reader
             .readUntilEndOfLine()
             .trimmingTrailingWhitespaces()
-
+        // https://spec.commonmark.org/0.29/#fenced-code-blocks
+        // cannot contain backtick
+        try require(!infoString.contains("`"))
         var code = ""
 
         while !reader.didReachEnd {
@@ -43,13 +45,16 @@ internal struct CodeBlock: Fragment {
 
             reader.advanceIndex()
         }
-
-        return CodeBlock(language: language, code: code)
+        // store the raw Substring for expediency here. The first word is the word is the language and the rest has no meaning.
+        // trim to the first word on output
+        return CodeBlock(language: infoString, code: code)
     }
 
     func html(usingURLs urls: NamedURLCollection,
               modifiers: ModifierCollection) -> String {
-        let languageClass = language.isEmpty ? "" : " class=\"language-\(language)\""
+        // https://spec.commonmark.org/0.29/#fenced-code-blocks
+        // first word of any info string is actually the language added
+        let languageClass = language.isEmpty ? "" : " class=\"language-\(language.split(separator: " ")[0])\""
         return "<pre><code\(languageClass)>\(code)</code></pre>"
     }
 

--- a/Sources/Ink/Internal/CodeBlock.swift
+++ b/Sources/Ink/Internal/CodeBlock.swift
@@ -30,7 +30,7 @@ internal struct CodeBlock: Fragment {
                 }
             }
 
-            if let escaped = reader.currentCharacter.escaped {
+            if let escaped = escaped(reader.currentCharacter) {
                 code.append(escaped)
             } else {
                 code.append(reader.currentCharacter)

--- a/Sources/Ink/Internal/CodeBlock.swift
+++ b/Sources/Ink/Internal/CodeBlock.swift
@@ -7,12 +7,13 @@
 internal struct CodeBlock: Fragment {
     var modifierTarget: Modifier.Target { .codeBlocks }
 
-    private static let marker: Character = "`"
+//    private static let marker: Character = "`"
 
     private var language: Substring
     private var code: String
 
     static func read(using reader: inout Reader) throws -> CodeBlock {
+        let marker = reader.currentCharacter // ` or ~ are expected but later need to implement indented code blocks.
         let startingMarkerCount = reader.readCount(of: marker)
         try require(startingMarkerCount >= 3)
         reader.discardWhitespaces()

--- a/Sources/Ink/Internal/CodeBlock.swift
+++ b/Sources/Ink/Internal/CodeBlock.swift
@@ -26,7 +26,7 @@ internal struct CodeBlock: Fragment {
         var code = ""
 
         while !reader.didReachEnd {
-            if code.last == "\n", reader.currentCharacter == marker {
+            if reader.previousCharacter == "\n", reader.currentCharacter == marker {
                 let markerCount = reader.readCount(of: marker)
 
                 if markerCount == startingMarkerCount {

--- a/Sources/Ink/Internal/CodeBlock.swift
+++ b/Sources/Ink/Internal/CodeBlock.swift
@@ -52,11 +52,9 @@ internal struct CodeBlock: Fragment {
                 }
             }
 
-            if let escaped = escapedMarkdownHTML(reader.currentCharacter) {
-                code.append(escaped)
-            } else {
-                code.append(reader.currentCharacter)
-            }
+            // I think we can now use the substring methods here too rather than copy to string
+            code.append(reader.currentCharacter)
+            
 
             reader.advanceIndex()
         }
@@ -69,8 +67,8 @@ internal struct CodeBlock: Fragment {
               modifiers: ModifierCollection) -> String {
         // https://spec.commonmark.org/0.29/#fenced-code-blocks
         // first word of any info string is actually the language added
-        let languageClass = language.isEmpty ? "" : " class=\"language-\(language.split(separator: " ")[0])\""
-        return "<pre><code\(languageClass)>\(code)</code></pre>"
+        let languageClass = language.isEmpty ? "" : " class=\"language-\(htmlEscapeASubstring(language.split(separator: " ")[0]))\""
+        return "<pre><code\(languageClass)>\(htmlEscapeAString(code))</code></pre>"
     }
 
     func plainText() -> String {

--- a/Sources/Ink/Internal/CodeBlock.swift
+++ b/Sources/Ink/Internal/CodeBlock.swift
@@ -35,7 +35,7 @@ internal struct CodeBlock: Fragment {
                 }
             }
 
-            if let escaped = escaped(reader.currentCharacter) {
+            if let escaped = escapedHtml(reader.currentCharacter) {
                 code.append(escaped)
             } else {
                 code.append(reader.currentCharacter)

--- a/Sources/Ink/Internal/FormattedText.swift
+++ b/Sources/Ink/Internal/FormattedText.swift
@@ -29,21 +29,20 @@ internal struct FormattedText: Readable, HTMLConvertible, PlainTextConvertible {
               modifiers: ModifierCollection) -> String {
         components.reduce(into: "") { string, component in
             switch component {
-            case .linebreak:
-                string.append("<br>")
             case .text(let text):
                 string.append(String(text))
             case .styleMarker(let marker):
-                let html = marker.html(usingURLs: urls, modifiers: modifiers)
-                string.append(html)
+                       let html = marker.html(usingURLs: urls, modifiers: modifiers)
+                       string.append(html)
             case .fragment(let fragment, let rawString):
                 let html = fragment.html(
                     usingURLs: urls,
                     rawString: rawString,
                     applyingModifiers: modifiers
                 )
-
                 string.append(html)
+            case .linebreak:
+                string.append("<br>")
             }
         }
     }
@@ -51,14 +50,14 @@ internal struct FormattedText: Readable, HTMLConvertible, PlainTextConvertible {
     func plainText() -> String {
         components.reduce(into: "") { string, component in
             switch component {
-            case .linebreak:
-                string.append("\n")
             case .text(let text):
                 string.append(String(text))
-            case .styleMarker:
-                break
             case .fragment(let fragment, _):
                 string.append(fragment.plainText())
+            case .styleMarker:
+                break
+            case .linebreak:
+                string.append("\n")
             }
         }
     }

--- a/Sources/Ink/Internal/FormattedText.swift
+++ b/Sources/Ink/Internal/FormattedText.swift
@@ -219,7 +219,7 @@ private extension FormattedText {
                         }
                     }
                 } else {
-                    if let escaped = escapedHtml(reader.currentCharacter) {
+                    if let escaped = escapedMarkdownHTML(reader.currentCharacter) {
                         addPendingTextIfNeeded()
                         text.components.append(.text(Substring(escaped)))
                         skipCharacter()

--- a/Sources/Ink/Internal/FormattedText.swift
+++ b/Sources/Ink/Internal/FormattedText.swift
@@ -219,7 +219,7 @@ private extension FormattedText {
                         }
                     }
                 } else {
-                    if let escaped = escaped(reader.currentCharacter) {
+                    if let escaped = escapedHtml(reader.currentCharacter) {
                         addPendingTextIfNeeded()
                         text.components.append(.text(Substring(escaped)))
                         skipCharacter()

--- a/Sources/Ink/Internal/Image.swift
+++ b/Sources/Ink/Internal/Image.swift
@@ -16,7 +16,7 @@ internal struct Image: Fragment {
 
     func html(usingURLs urls: NamedURLCollection,
               modifiers: ModifierCollection) -> String {
-        let url = link.target.url(from: urls)
+        let url = uriEncoded(uriSubstring: link.target.url(from: urls))
         var alt = link.text.html(usingURLs: urls, modifiers: modifiers)
 
         if !alt.isEmpty {

--- a/Sources/Ink/Internal/InlineCode.swift
+++ b/Sources/Ink/Internal/InlineCode.swift
@@ -21,7 +21,7 @@ struct InlineCode: Fragment {
                 reader.advanceIndex()
                 return InlineCode(code: code)
             default:
-                if let escaped = reader.currentCharacter.escaped {
+                if let escaped = escaped(reader.currentCharacter) {
                     code.append(escaped)
                 } else {
                     code.append(reader.currentCharacter)

--- a/Sources/Ink/Internal/InlineCode.swift
+++ b/Sources/Ink/Internal/InlineCode.swift
@@ -6,7 +6,7 @@
 
 struct InlineCode: Fragment {
     var modifierTarget: Modifier.Target { .inlineCode }
-
+    // This should probably evolve to a Substring too
     private var code: String
 
     static func read(using reader: inout Reader) throws -> InlineCode {
@@ -21,12 +21,7 @@ struct InlineCode: Fragment {
                 reader.advanceIndex()
                 return InlineCode(code: code)
             default:
-                if let escaped = escapedMarkdownHTML(reader.currentCharacter) {
-                    code.append(escaped)
-                } else {
-                    code.append(reader.currentCharacter)
-                }
-
+                code.append(reader.currentCharacter)
                 reader.advanceIndex()
             }
         }
@@ -36,7 +31,7 @@ struct InlineCode: Fragment {
 
     func html(usingURLs urls: NamedURLCollection,
               modifiers: ModifierCollection) -> String {
-        return "<code>\(code)</code>"
+        return "<code>\(htmlEscapeAString(code))</code>"
     }
 
     func plainText() -> String {

--- a/Sources/Ink/Internal/InlineCode.swift
+++ b/Sources/Ink/Internal/InlineCode.swift
@@ -21,7 +21,7 @@ struct InlineCode: Fragment {
                 reader.advanceIndex()
                 return InlineCode(code: code)
             default:
-                if let escaped = escapedHtml(reader.currentCharacter) {
+                if let escaped = escapedMarkdownHTML(reader.currentCharacter) {
                     code.append(escaped)
                 } else {
                     code.append(reader.currentCharacter)

--- a/Sources/Ink/Internal/InlineCode.swift
+++ b/Sources/Ink/Internal/InlineCode.swift
@@ -21,7 +21,7 @@ struct InlineCode: Fragment {
                 reader.advanceIndex()
                 return InlineCode(code: code)
             default:
-                if let escaped = escaped(reader.currentCharacter) {
+                if let escaped = escapedHtml(reader.currentCharacter) {
                     code.append(escaped)
                 } else {
                     code.append(reader.currentCharacter)

--- a/Sources/Ink/Internal/Link.swift
+++ b/Sources/Ink/Internal/Link.swift
@@ -30,7 +30,7 @@ internal struct Link: Fragment {
 
     func html(usingURLs urls: NamedURLCollection,
               modifiers: ModifierCollection) -> String {
-        let url = target.url(from: urls)
+        let url = uriEncoded(uriSubstring: target.url(from: urls))
         let title = text.html(usingURLs: urls, modifiers: modifiers)
         return "<a href=\"\(url)\">\(title)</a>"
     }

--- a/Sources/Ink/Internal/Readable.swift
+++ b/Sources/Ink/Internal/Readable.swift
@@ -10,10 +10,10 @@ internal protocol Readable {
 
 extension Readable {
     static func readOrRewind(using reader: inout Reader) throws -> Self {
-        guard reader.previousCharacter != "\\" else {
-            throw Reader.Error()
-        }
-
+//        guard reader.previousCharacter != "\\" else {
+//            throw Reader.Error()
+//        }
+// Not sure why this is here it is interfering with proper backslash handling
         let previousReader = reader
 
         do {

--- a/Tests/InkTests/CodeTests.swift
+++ b/Tests/InkTests/CodeTests.swift
@@ -29,7 +29,26 @@ final class CodeTests: XCTestCase {
 
         XCTAssertEqual(html, "<pre><code>code()\nblock()\n</code></pre>")
     }
-
+    
+    // https://github.com/commonmark/commonmark-spec
+    // spec.txt lines 1653-1662
+    func testCodeBlockWithTilde() {
+        let html = MarkdownParser().html(from: """
+        ~~~
+        <
+         >
+        ~~~
+        """)
+        
+        let normalizedCM = #####"""
+            <pre><code>&lt;
+             &gt;
+            </code></pre>
+            """#####
+        
+        XCTAssertEqual(html,normalizedCM)
+    }
+    
     func testCodeBlockWithBackticksAndLabel() {
         let html = MarkdownParser().html(from: """
         ```swift
@@ -197,6 +216,7 @@ extension CodeTests {
             ("testInlineCode", testInlineCode),
             ("testInlineCodeLeftToRight", testInlineCodeLeftToRight),
             ("testCodeBlockWithJustBackticks", testCodeBlockWithJustBackticks),
+            ("testCodeBlockWithTilde", testCodeBlockWithTilde),
             ("testCodeBlockWithBackticksAndLabel", testCodeBlockWithBackticksAndLabel),
             ("testCodeBlockWithBackticksAndLongInfoString", testCodeBlockWithBackticksAndLongInfoString),
             ("testCodeBlockWithSillyLanguageName", testCodeBlockWithSillyLanguageName),

--- a/Tests/InkTests/CodeTests.swift
+++ b/Tests/InkTests/CodeTests.swift
@@ -174,6 +174,22 @@ final class CodeTests: XCTestCase {
         - Not a list\n</code></pre>
         """)
     }
+    
+    func testCodeBlockBetweenParagraphs() {
+        // Derived from CommonMark spec lines 2251-2262
+        let html = MarkdownParser().html(from: #####"""
+        foo
+        ```
+        bar
+        ```
+        baz
+        """#####)
+        
+        XCTAssertEqual(html, #####"""
+        <p>foo</p><pre><code>bar
+        </code></pre><p>baz</p>
+        """#####)
+    }
 }
 
 extension CodeTests {
@@ -191,7 +207,8 @@ extension CodeTests {
             ("testCodeBlockFakeClosureAndFileEndingBlock", testCodeBlockFakeClosureAndFileEndingBlock),
             ("testEncodingSpecialCharactersWithinCodeBlock", testEncodingSpecialCharactersWithinCodeBlock),
             ("testEscapeBehaviorWithinCodeBlock", testEscapeBehaviorWithinCodeBlock),
-            ("testIgnoringFormattingWithinCodeBlock", testIgnoringFormattingWithinCodeBlock)
+            ("testIgnoringFormattingWithinCodeBlock", testIgnoringFormattingWithinCodeBlock),
+            ("testCodeBlockBetweenParagraphs", testCodeBlockBetweenParagraphs)
         ]
     }
 }

--- a/Tests/InkTests/CodeTests.swift
+++ b/Tests/InkTests/CodeTests.swift
@@ -14,7 +14,7 @@ final class CodeTests: XCTestCase {
     }
 
     func testInlineCodeLeftToRight() {
-        // Derived from CommonMark spec lines 5842-5846
+        // Derived from CommonMark spec lines 5499-5503
         let html = MarkdownParser().html(from: "`hi`lo`")
         XCTAssertEqual(html, "<p><code>hi</code>lo`</p>")
     }
@@ -41,7 +41,7 @@ final class CodeTests: XCTestCase {
     }
     
     func testCodeBlockWithBackticksAndLongInfoString() {
-        // Derived from CommonMark spec lines 2304-2315
+        // Derived from CommonMark spec lines 1961-1972
         let html = MarkdownParser().html(from: """
         ````    ruby startline=3 $%@#$
         def foo(x)
@@ -59,7 +59,7 @@ final class CodeTests: XCTestCase {
     }
     
     func testCodeBlockWithSillyLanguageName() {
-        // Derived from CommonMark spec lines 2318-2323
+        // Derived from CommonMark spec lines 1975-1980
         let html = MarkdownParser().html(from:
         #####"""
         ```;
@@ -74,7 +74,7 @@ final class CodeTests: XCTestCase {
     }
     
     func testCodeBlockWithBackticksAndLabelNeedingTrimming() {
-       // there are 2 spaces after the swift label that need trimming too
+       // there should be 2 spaces after the swift label below that need trimming too
        let html = MarkdownParser().html(from: """
        ``` swift  
        code()
@@ -85,7 +85,6 @@ final class CodeTests: XCTestCase {
    }
     
     func testCodeBlockManyBackticks() {
-        // there are 2 spaces after the swift label that need trimming too
         let html = MarkdownParser().html(from: """
         
         ```````````````````````````````` foo
@@ -97,7 +96,7 @@ final class CodeTests: XCTestCase {
     }
     
     func testCodeBlockSufficientBackticks() {
-        // Derived from CommonMark spec lines 2046-2055
+        // Derived from CommonMark spec 0.29 lines 1703-1712
         let html = MarkdownParser().html(from: """
            ````
            aaa
@@ -113,7 +112,7 @@ final class CodeTests: XCTestCase {
     }
     
     func testCodeBlockFakeClosureAndFileEndingBlock() {
-        // Derived from CommonMark spec lines 2046-2055
+        // To complete code coverage for bad closing of block cases
         let html = MarkdownParser().html(from: #####"""
            ````
            aaa
@@ -176,7 +175,7 @@ final class CodeTests: XCTestCase {
     }
     
     func testCodeBlockBetweenParagraphs() {
-        // Derived from CommonMark spec lines 2251-2262
+        // Derived from CommonMark spec 0.29 lines 1908-1919
         let html = MarkdownParser().html(from: #####"""
         foo
         ```

--- a/Tests/InkTests/CodeTests.swift
+++ b/Tests/InkTests/CodeTests.swift
@@ -96,6 +96,38 @@ final class CodeTests: XCTestCase {
         XCTAssertEqual(html, "<pre><code class=\"language-foo\">bar\n</code></pre>")
     }
     
+    func testCodeBlockSufficientBackticks() {
+        // Derived from CommonMark spec lines 2046-2055
+        let html = MarkdownParser().html(from: """
+           ````
+           aaa
+           ```
+           ``````
+           """)
+        
+        XCTAssertEqual(html, #####"""
+           <pre><code>aaa
+           ```
+           </code></pre>
+           """#####)
+    }
+    
+    func testCodeBlockFakeClosureAndFileEndingBlock() {
+        // Derived from CommonMark spec lines 2046-2055
+        let html = MarkdownParser().html(from: #####"""
+           ````
+           aaa
+           ```` this is \really code \" &
+           ```
+           """#####)
+        
+        XCTAssertEqual(html, #####"""
+           <pre><code>aaa
+           ```` this is \really code \&quot; &amp;
+           ```</code></pre>
+           """#####)
+    }
+
     func testEncodingSpecialCharactersWithinCodeBlock() {
         let html = MarkdownParser().html(from: """
         ```swift
@@ -155,6 +187,8 @@ extension CodeTests {
             ("testCodeBlockWithSillyLanguageName", testCodeBlockWithSillyLanguageName),
             ("testCodeBlockWithBackticksAndLabelNeedingTrimming", testCodeBlockWithBackticksAndLabelNeedingTrimming),
             ("testCodeBlockManyBackticks", testCodeBlockManyBackticks),
+            ("testCodeBlockSufficientBackticks", testCodeBlockSufficientBackticks),
+            ("testCodeBlockFakeClosureAndFileEndingBlock", testCodeBlockFakeClosureAndFileEndingBlock),
             ("testEncodingSpecialCharactersWithinCodeBlock", testEncodingSpecialCharactersWithinCodeBlock),
             ("testEscapeBehaviorWithinCodeBlock", testEscapeBehaviorWithinCodeBlock),
             ("testIgnoringFormattingWithinCodeBlock", testIgnoringFormattingWithinCodeBlock)

--- a/Tests/InkTests/CodeTests.swift
+++ b/Tests/InkTests/CodeTests.swift
@@ -40,6 +40,39 @@ final class CodeTests: XCTestCase {
         XCTAssertEqual(html, "<pre><code class=\"language-swift\">code()\n</code></pre>")
     }
     
+    func testCodeBlockWithBackticksAndLongInfoString() {
+        // Derived from CommonMark spec lines 2304-2315
+        let html = MarkdownParser().html(from: """
+        ````    ruby startline=3 $%@#$
+        def foo(x)
+          return 3
+        end
+        ````
+        """)
+
+        XCTAssertEqual(html, """
+        <pre><code class="language-ruby">def foo(x)
+          return 3
+        end
+        </code></pre>
+        """)
+    }
+    
+    func testCodeBlockWithSillyLanguageName() {
+        // Derived from CommonMark spec lines 2318-2323
+        let html = MarkdownParser().html(from:
+        #####"""
+        ```;
+        ```
+        """#####
+        + "\n"
+        )
+
+        XCTAssertEqual(html, """
+        <pre><code class="language-;"></code></pre>
+        """)
+    }
+    
     func testCodeBlockWithBackticksAndLabelNeedingTrimming() {
        // there are 2 spaces after the swift label that need trimming too
        let html = MarkdownParser().html(from: """
@@ -118,6 +151,8 @@ extension CodeTests {
             ("testInlineCodeLeftToRight", testInlineCodeLeftToRight),
             ("testCodeBlockWithJustBackticks", testCodeBlockWithJustBackticks),
             ("testCodeBlockWithBackticksAndLabel", testCodeBlockWithBackticksAndLabel),
+            ("testCodeBlockWithBackticksAndLongInfoString", testCodeBlockWithBackticksAndLongInfoString),
+            ("testCodeBlockWithSillyLanguageName", testCodeBlockWithSillyLanguageName),
             ("testCodeBlockWithBackticksAndLabelNeedingTrimming", testCodeBlockWithBackticksAndLabelNeedingTrimming),
             ("testCodeBlockManyBackticks", testCodeBlockManyBackticks),
             ("testEncodingSpecialCharactersWithinCodeBlock", testEncodingSpecialCharactersWithinCodeBlock),

--- a/Tests/InkTests/CodeTests.swift
+++ b/Tests/InkTests/CodeTests.swift
@@ -68,6 +68,19 @@ final class CodeTests: XCTestCase {
         <pre><code class="language-swift">Generic&lt;T&gt;() &amp;&amp; expression()\n</code></pre>
         """)
     }
+    
+    func testEscapeBehaviorWithinCodeBlock() {
+        let html = MarkdownParser().html(from: """
+        ```swi\ft
+        \< < \& & \" " \> >
+        \a a \\ \` `
+        ```
+        """)
+
+        XCTAssertEqual(html, """
+        <pre><code class="language-swift">\&lt; &lt; \&amp; &amp; \&quot; &quot; \&gt; &gt;\n\a a \\ \` `\n</code></pre>
+        """)
+    }
 
     func testIgnoringFormattingWithinCodeBlock() {
         let html = MarkdownParser().html(from: """

--- a/Tests/InkTests/CodeTests.swift
+++ b/Tests/InkTests/CodeTests.swift
@@ -13,6 +13,12 @@ final class CodeTests: XCTestCase {
         XCTAssertEqual(html, "<p>Hello <code>inline.code()</code></p>")
     }
 
+    func testInlineCodeLeftToRight() {
+        // Derived from CommonMark spec lines 5842-5846
+        let html = MarkdownParser().html(from: "`hi`lo`")
+        XCTAssertEqual(html, "<p><code>hi</code>lo`</p>")
+    }
+    
     func testCodeBlockWithJustBackticks() {
         let html = MarkdownParser().html(from: """
         ```
@@ -70,16 +76,22 @@ final class CodeTests: XCTestCase {
     }
     
     func testEscapeBehaviorWithinCodeBlock() {
-        let html = MarkdownParser().html(from: """
-        ```swi\ft
+        let html = MarkdownParser().html(from:
+        #####"""
+        ```swift
         \< < \& & \" " \> >
         \a a \\ \` `
         ```
-        """)
+        """#####
+        )
 
-        XCTAssertEqual(html, """
-        <pre><code class="language-swift">\&lt; &lt; \&amp; &amp; \&quot; &quot; \&gt; &gt;\n\a a \\ \` `\n</code></pre>
-        """)
+        XCTAssertEqual(html,
+        #####"""
+        <pre><code class="language-swift">\&lt; &lt; \&amp; &amp; \&quot; &quot; \&gt; &gt;
+        \a a \\ \` `
+        </code></pre>
+        """#####
+        )
     }
 
     func testIgnoringFormattingWithinCodeBlock() {
@@ -103,11 +115,13 @@ extension CodeTests {
     static var allTests: Linux.TestList<CodeTests> {
         return [
             ("testInlineCode", testInlineCode),
+            ("testInlineCodeLeftToRight", testInlineCodeLeftToRight),
             ("testCodeBlockWithJustBackticks", testCodeBlockWithJustBackticks),
             ("testCodeBlockWithBackticksAndLabel", testCodeBlockWithBackticksAndLabel),
             ("testCodeBlockWithBackticksAndLabelNeedingTrimming", testCodeBlockWithBackticksAndLabelNeedingTrimming),
             ("testCodeBlockManyBackticks", testCodeBlockManyBackticks),
             ("testEncodingSpecialCharactersWithinCodeBlock", testEncodingSpecialCharactersWithinCodeBlock),
+            ("testEscapeBehaviorWithinCodeBlock", testEscapeBehaviorWithinCodeBlock),
             ("testIgnoringFormattingWithinCodeBlock", testIgnoringFormattingWithinCodeBlock)
         ]
     }

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -69,6 +69,80 @@ final class LinkTests: XCTestCase {
         let html = MarkdownParser().html(from: "[\\[Hello\\]](hello)")
         XCTAssertEqual(html, #"<p><a href="hello">[Hello]</a></p>"#)
     }
+     // A link can contain fragment identifiers and queries:
+     //
+     //
+     // https://github.com/github/cmark-gfm/blob/master/test/spec.txt
+     // spec.txt lines 7953-7963
+     func testExample509() {
+         let markdownTest =
+         #####"""
+         [link](#fragment)
+         
+         [link](http://example.com#fragment)
+         
+         [link](http://example.com?foo=3#frag)\#####n
+         """#####
+     
+         let html = MarkdownParser().html(from: markdownTest)
+         .replacingOccurrences(of: ">\n<", with: "><")
+         
+       //<p><a href="#fragment">link</a></p>
+       //<p><a href="http://example.com#fragment">link</a></p>
+       //<p><a href="http://example.com?foo=3#frag">link</a></p>
+         let normalizedCM = #####"""
+         <p><a href="#fragment">link</a></p><p><a href="http://example.com#fragment">link</a></p><p><a href="http://example.com?foo=3#frag">link</a></p>
+         """#####
+     
+         XCTAssertEqual(html,normalizedCM)
+     }
+
+    // Unicode case fold is used:
+    //
+    //
+    // https://github.com/github/cmark-gfm/blob/master/test/spec.txt
+    // spec.txt lines 8381-8387
+    func testExample548() {
+        let markdownTest =
+        #####"""
+        [Толпой][Толпой] is a Russian word.
+        
+        [ТОЛПОЙ]: /url\#####n
+        """#####
+    
+        let html = MarkdownParser().html(from: markdownTest)
+        .replacingOccurrences(of: ">\n<", with: "><")
+        
+      //<p><a href="/url">Толпой</a> is a Russian word.</p>
+        let normalizedCM = #####"""
+        <p><a href="/url">Толпой</a> is a Russian word.</p>
+        """#####
+    
+        XCTAssertEqual(html,normalizedCM)
+    }
+
+    // Note that a backslash before a non-escapable character is
+      // just a backslash:
+      //
+      //
+      // https://github.com/github/cmark-gfm/blob/master/test/spec.txt
+      // spec.txt lines 7969-7973
+      func testExample510() {
+          let markdownTest =
+          #####"""
+          [link](foo\bar)
+          """#####
+      
+          let html = MarkdownParser().html(from: markdownTest)
+          
+          
+        //<p><a href="foo%5Cbar">link</a></p>
+          let normalizedCM = #####"""
+          <p><a href="foo%5Cbar">link</a></p>
+          """#####
+      
+          XCTAssertEqual(html,normalizedCM)
+      }
     
 }
 
@@ -83,8 +157,11 @@ extension LinkTests {
             ("testBoldLinkWithExternalMarkers", testBoldLinkWithExternalMarkers),
             ("testLinkWithUnderscores", testLinkWithUnderscores),
             ("testUnterminatedLink", testUnterminatedLink),
-            ("testLinkWithEscapedSquareBrackets", testLinkWithEscapedSquareBrackets)
-//            ("testBackslashInURL", testBackslashInURL)
+            ("testLinkWithEscapedSquareBrackets", testLinkWithEscapedSquareBrackets),
+            ("testExample509", testExample509),
+            ("testExample548", testExample548),
+            ("testExample510", testExample510)
+
         ]
     }
 }

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -32,7 +32,7 @@ final class LinkTests: XCTestCase {
         [ΑΓΩ]: /φου
         """)
 
-        XCTAssertEqual(html, #"<p><a href="/url">Title</a> <a href="/φου">Title</a></p>"#)
+        XCTAssertEqual(html, #"<p><a href="/url">Title</a>\#n<a href="/φου">Title</a></p>"#)
     }
 
     func testNumericLinkWithReference() {

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -69,22 +69,7 @@ final class LinkTests: XCTestCase {
         let html = MarkdownParser().html(from: "[\\[Hello\\]](hello)")
         XCTAssertEqual(html, #"<p><a href="hello">[Hello]</a></p>"#)
     }
-// This commonmark test can be enabled when a more conformant Link parser is ready for testing
-// https://spec.commonmark.org/0.29/#links
-//   func testBackslashInURL() {
-//       // Derived from CommonMark spec lines 596-600
-//       // Backslash work in all other contexts, including URLs
-//       let inputString =
-//       #####"""
-//       [foo](/bar\* "ti\*tle")
-//       """#####
-//       let html = MarkdownParser().html(from: inputString)
-//
-//       let properAnswer = #####"""
-//       <p><a href="/bar*" title="ti*tle">foo</a></p>
-//       """#####
-//       XCTAssertEqual(html, properAnswer)
-//   }
+    
 }
 
 extension LinkTests {

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -69,21 +69,22 @@ final class LinkTests: XCTestCase {
         let html = MarkdownParser().html(from: "[\\[Hello\\]](hello)")
         XCTAssertEqual(html, #"<p><a href="hello">[Hello]</a></p>"#)
     }
-    
-   func testBackslashInURL() {
-       // Derived from CommonMark spec lines 596-600
-       // Backslash work in all other contexts, including URLs
-       let inputString =
-       #####"""
-       [foo](/bar\* "ti\*tle")
-       """#####
-       let html = MarkdownParser().html(from: inputString)
-       
-       let properAnswer = #####"""
-       <p><a href="/bar*" title="ti*tle">foo</a></p>
-       """#####
-       XCTAssertEqual(html, properAnswer)
-   }
+// This commonmark test can be enabled when a more conformant Link parser is ready for testing
+// https://spec.commonmark.org/0.29/#links
+//   func testBackslashInURL() {
+//       // Derived from CommonMark spec lines 596-600
+//       // Backslash work in all other contexts, including URLs
+//       let inputString =
+//       #####"""
+//       [foo](/bar\* "ti\*tle")
+//       """#####
+//       let html = MarkdownParser().html(from: inputString)
+//
+//       let properAnswer = #####"""
+//       <p><a href="/bar*" title="ti*tle">foo</a></p>
+//       """#####
+//       XCTAssertEqual(html, properAnswer)
+//   }
 }
 
 extension LinkTests {
@@ -97,8 +98,8 @@ extension LinkTests {
             ("testBoldLinkWithExternalMarkers", testBoldLinkWithExternalMarkers),
             ("testLinkWithUnderscores", testLinkWithUnderscores),
             ("testUnterminatedLink", testUnterminatedLink),
-            ("testLinkWithEscapedSquareBrackets", testLinkWithEscapedSquareBrackets),
-            ("testBackslashInURL", testBackslashInURL)
+            ("testLinkWithEscapedSquareBrackets", testLinkWithEscapedSquareBrackets)
+//            ("testBackslashInURL", testBackslashInURL)
         ]
     }
 }

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -69,6 +69,21 @@ final class LinkTests: XCTestCase {
         let html = MarkdownParser().html(from: "[\\[Hello\\]](hello)")
         XCTAssertEqual(html, #"<p><a href="hello">[Hello]</a></p>"#)
     }
+    
+   func testBackslashInURL() {
+       // Derived from CommonMark spec lines 596-600
+       // Backslash work in all other contexts, including URLs
+       let inputString =
+       #####"""
+       [foo](/bar\* "ti\*tle")
+       """#####
+       let html = MarkdownParser().html(from: inputString)
+       
+       let properAnswer = #####"""
+       <p><a href="/bar*" title="ti*tle">foo</a></p>
+       """#####
+       XCTAssertEqual(html, properAnswer)
+   }
 }
 
 extension LinkTests {
@@ -82,7 +97,8 @@ extension LinkTests {
             ("testBoldLinkWithExternalMarkers", testBoldLinkWithExternalMarkers),
             ("testLinkWithUnderscores", testLinkWithUnderscores),
             ("testUnterminatedLink", testUnterminatedLink),
-            ("testLinkWithEscapedSquareBrackets", testLinkWithEscapedSquareBrackets)
+            ("testLinkWithEscapedSquareBrackets", testLinkWithEscapedSquareBrackets),
+            ("testBackslashInURL", testBackslashInURL)
         ]
     }
 }

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -166,11 +166,11 @@ final class TextFormattingTests: XCTestCase {
     func testOtherCharactersNotEscaped() {
         // Derived from CommonMark spec lines 498-502
         // watch out as there are tab characters in this test \#####t
-        let allTheSpecialASCIIChars =
+        let inputString =
         #####"""
         \\#####t\A\a\ \3\φ\«
         """#####
-        let html = MarkdownParser().html(from: allTheSpecialASCIIChars)
+        let html = MarkdownParser().html(from: inputString)
         
         let properAnswer = #####"""
         <p>\\#####t\A\a\ \3\φ\«</p>
@@ -182,7 +182,7 @@ final class TextFormattingTests: XCTestCase {
         // Derived from CommonMark spec lines 508-528
         // Escaped characters are treated as regular characters and do
         // not have their usual Markdown meanings:
-        let allTheSpecialASCIIChars =
+        let inputString =
         #####"""
         \*not emphasized*
         \<br/> not a tag
@@ -194,10 +194,25 @@ final class TextFormattingTests: XCTestCase {
         \[foo]: /url "not a reference"
         \&ouml; not a character entity
         """#####
-        let html = MarkdownParser().html(from: allTheSpecialASCIIChars)
+        let html = MarkdownParser().html(from: inputString)
         
         let properAnswer = #####"""
         <p>*not emphasized* &lt;br/&gt; not a tag [not a link](/foo) `not code` 1. not a list * not a list # not a heading [foo]: /url &quot;not a reference&quot; &amp;ouml; not a character entity</p>
+        """#####
+        XCTAssertEqual(html, properAnswer)
+    }
+    
+    func testEscapeOfBackslash() {
+        // Derived from CommonMark spec lines 533-537
+        // If a backslash is itself escaped, the following character is not:
+        let inputString =
+        #####"""
+        \\*emphasis*
+        """#####
+        let html = MarkdownParser().html(from: inputString)
+        
+        let properAnswer = #####"""
+        <p>\<em>emphasis</em></p>
         """#####
         XCTAssertEqual(html, properAnswer)
     }
@@ -234,7 +249,8 @@ extension TextFormattingTests {
             ("testEscapedHardLinebreak", testEscapedHardLinebreak),
             ("testEscapedPunctuation", testEscapedPunctuation),
             ("testOtherCharactersNotEscaped", testOtherCharactersNotEscaped),
-            ("testEscapesThatOverrideMarkdown", testEscapesThatOverrideMarkdown)
+            ("testEscapesThatOverrideMarkdown", testEscapesThatOverrideMarkdown),
+            ("testEscapeOfBackslash", testEscapeOfBackslash)
         ]
     }
 }

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -148,6 +148,35 @@ final class TextFormattingTests: XCTestCase {
 
         XCTAssertEqual(html, "<p>Line 1<br/>Line 2</p>")
     }
+    
+    func testEscapedPunctuation() {
+        // Derived from CommonMark spec lines 488-492
+        let allTheSpecialASCIIChars =
+        #####"""
+        \!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~
+        """#####
+        let html = MarkdownParser().html(from: allTheSpecialASCIIChars)
+        
+        let properAnswer = #####"""
+        <p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\]^_`{|}~</p>
+        """#####
+        XCTAssertEqual(html, properAnswer)
+    }
+    
+    func testOtherCharactersNotEscaped() {
+        // Derived from CommonMark spec lines 498-502
+        // watch out as there are tab characters in this test \#####t
+        let allTheSpecialASCIIChars =
+        #####"""
+        \\#####t\A\a\ \3\φ\«
+        """#####
+        let html = MarkdownParser().html(from: allTheSpecialASCIIChars)
+        
+        let properAnswer = #####"""
+        <p>\\#####t\A\a\ \3\φ\«</p>
+        """#####
+        XCTAssertEqual(html, properAnswer)
+    }
 }
 
 extension TextFormattingTests {
@@ -178,7 +207,9 @@ extension TextFormattingTests {
             ("testMultiLineBlockquote", testMultiLineBlockquote),
             ("testEscapingSymbolsWithBackslash", testEscapingSymbolsWithBackslash),
             ("testDoubleSpacedHardLinebreak", testDoubleSpacedHardLinebreak),
-            ("testEscapedHardLinebreak", testEscapedHardLinebreak)
+            ("testEscapedHardLinebreak", testEscapedHardLinebreak),
+            ("testEscapedPunctuation", testEscapedPunctuation),
+            ("testOtherCharactersNotEscaped", testOtherCharactersNotEscaped)
         ]
     }
 }

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -247,6 +247,30 @@ final class TextFormattingTests: XCTestCase {
         XCTAssertEqual(html, properAnswer)
     }
     
+    // Hard line breaks are for separating inline content within a block.
+    // Neither syntax for hard line breaks works at the end of a paragraph or
+    // other block element:
+    //
+    //
+    // https://github.com/github/cmark-gfm/blob/master/test/spec.txt
+    // spec.txt lines 9798-9802
+    func testExample665() {
+        let markdownTest =
+        #####"""
+        foo\
+        """#####
+    
+        let html = MarkdownParser().html(from: markdownTest)
+        
+        
+      //<p>foo\</p>
+        let normalizedCM = #####"""
+        <p>foo\</p>
+        """#####
+    
+        XCTAssertEqual(html,normalizedCM)
+    }
+    
     func testCodeAreasPreserveBackslash() {
         // Derived from GitHub Flavored Markdown Spec lines 5860-5864
         // Backslash escapes do not work in code blocks, code spans, autolinks, or
@@ -360,6 +384,7 @@ extension TextFormattingTests {
             ("testEscapesThatOverrideMarkdown", testEscapesThatOverrideMarkdown),
             ("testEscapeOfBackslash", testEscapeOfBackslash),
             ("testCodeAreasPreserveBackslash", testCodeAreasPreserveBackslash),
+            ("testExample665", testExample665),
             ("testRawHTMLPreserveBackslash", testRawHTMLPreserveBackslash),
             ("testNullCharacterIsEscapedToHexFFFD", testNullCharacterIsEscapedToHexFFFD)
         ]

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -229,7 +229,8 @@ final class TextFormattingTests: XCTestCase {
         let html = MarkdownParser().html(from: inputString)
         
         let properAnswer = #####"""
-        <pre><code>\[\]</code></pre>
+        <pre><code>\[\]
+        </code></pre>
         """#####
         XCTAssertEqual(html, properAnswer)
     }

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -13,6 +13,16 @@ final class TextFormattingTests: XCTestCase {
         XCTAssertEqual(html, "<p>Hello, world!</p>")
     }
 
+    func testParagraphEndsWithNewline() {
+        let html = MarkdownParser().html(from: "Hello, world!\n")
+        XCTAssertEqual(html, "<p>Hello, world!</p>")
+    }
+    
+    func testParagraphEndsWithWhitespace() {
+        let html = MarkdownParser().html(from: "Hello, world! ")
+        XCTAssertEqual(html, "<p>Hello, world!</p>")
+    }
+    
     func testItalicText() {
         let html = MarkdownParser().html(from: "Hello, *world*!")
         XCTAssertEqual(html, "<p>Hello, <em>world</em>!</p>")
@@ -256,6 +266,8 @@ extension TextFormattingTests {
     static var allTests: Linux.TestList<TextFormattingTests> {
         return [
             ("testParagraph", testParagraph),
+            ("testParagraphEndsWithNewline", testParagraphEndsWithNewline),
+            ("testParagraphEndsWithWhitespace", testParagraphEndsWithWhitespace),
             ("testItalicText", testItalicText),
             ("testBoldText", testBoldText),
             ("testItalicBoldText", testItalicBoldText),

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -27,6 +27,11 @@ final class TextFormattingTests: XCTestCase {
         XCTAssertEqual(html, "<p>Hello, world!</p>")
     }
     
+    func testParagraphWhitespaceRemoval() {
+           let html = MarkdownParser().html(from: "Hello,  world!\n        How is it going?   ")
+           XCTAssertEqual(html, "<p>Hello,  world!\n        How is it going?</p>")
+       }
+    
     func testItalicText() {
         let html = MarkdownParser().html(from: "Hello, *world*!")
         XCTAssertEqual(html, "<p>Hello, <em>world</em>!</p>")
@@ -148,7 +153,7 @@ final class TextFormattingTests: XCTestCase {
         \\*Not italic\\*
         """)
 
-        XCTAssertEqual(html, "<p># Not a title *Not italic*</p>")
+        XCTAssertEqual(html, "<p># Not a title\n*Not italic*</p>")
     }
 
     func testDoubleSpacedHardLinebreak() {
@@ -214,7 +219,15 @@ final class TextFormattingTests: XCTestCase {
         let html = MarkdownParser().html(from: inputString)
         
         let properAnswer = #####"""
-        <p>*not emphasized* &lt;br/&gt; not a tag [not a link](/foo) `not code` 1. not a list * not a list # not a heading [foo]: /url &quot;not a reference&quot; &amp;ouml; not a character entity</p>
+        <p>*not emphasized*
+        &lt;br/&gt; not a tag
+        [not a link](/foo)
+        `not code`
+        1. not a list
+        * not a list
+        # not a heading
+        [foo]: /url &quot;not a reference&quot;
+        &amp;ouml; not a character entity</p>
         """#####
         XCTAssertEqual(html, properAnswer)
     }
@@ -316,6 +329,7 @@ extension TextFormattingTests {
             ("testParagraph", testParagraph),
             ("testParagraphEndsWithNewline", testParagraphEndsWithNewline),
             ("testParagraphEndsWithWhitespace", testParagraphEndsWithWhitespace),
+            ("testParagraphWhitespaceRemoval", testParagraphWhitespaceRemoval),
             ("testItalicText", testItalicText),
             ("testBoldText", testBoldText),
             ("testItalicBoldText", testItalicBoldText),

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -177,6 +177,30 @@ final class TextFormattingTests: XCTestCase {
         """#####
         XCTAssertEqual(html, properAnswer)
     }
+    
+    func testEscapesThatOverrideMarkdown() {
+        // Derived from CommonMark spec lines 508-528
+        // Escaped characters are treated as regular characters and do
+        // not have their usual Markdown meanings:
+        let allTheSpecialASCIIChars =
+        #####"""
+        \*not emphasized*
+        \<br/> not a tag
+        \[not a link](/foo)
+        \`not code`
+        1\. not a list
+        \* not a list
+        \# not a heading
+        \[foo]: /url "not a reference"
+        \&ouml; not a character entity
+        """#####
+        let html = MarkdownParser().html(from: allTheSpecialASCIIChars)
+        
+        let properAnswer = #####"""
+        <p>*not emphasized* &lt;br/&gt; not a tag [not a link](/foo) `not code` 1. not a list * not a list # not a heading [foo]: /url &quot;not a reference&quot; &amp;ouml; not a character entity</p>
+        """#####
+        XCTAssertEqual(html, properAnswer)
+    }
 }
 
 extension TextFormattingTests {
@@ -209,7 +233,8 @@ extension TextFormattingTests {
             ("testDoubleSpacedHardLinebreak", testDoubleSpacedHardLinebreak),
             ("testEscapedHardLinebreak", testEscapedHardLinebreak),
             ("testEscapedPunctuation", testEscapedPunctuation),
-            ("testOtherCharactersNotEscaped", testOtherCharactersNotEscaped)
+            ("testOtherCharactersNotEscaped", testOtherCharactersNotEscaped),
+            ("testEscapesThatOverrideMarkdown", testEscapesThatOverrideMarkdown)
         ]
     }
 }

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -160,7 +160,7 @@ final class TextFormattingTests: XCTestCase {
     }
     
     func testEscapedPunctuation() {
-        // Derived from CommonMark spec lines 488-492
+        // Derived from CommonMark spec lines 5513-5517
         let allTheSpecialASCIIChars =
         #####"""
         \!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~
@@ -174,7 +174,7 @@ final class TextFormattingTests: XCTestCase {
     }
     
     func testOtherCharactersNotEscaped() {
-        // Derived from CommonMark spec lines 498-502
+        // Derived from CommonMark spec lines 5523-5527
         // watch out as there are tab characters in this test \#####t
         let inputString =
         #####"""
@@ -189,7 +189,7 @@ final class TextFormattingTests: XCTestCase {
     }
     
     func testEscapesThatOverrideMarkdown() {
-        // Derived from CommonMark spec lines 508-528
+        // Derived from CommonMark spec lines 5533-5553
         // Escaped characters are treated as regular characters and do
         // not have their usual Markdown meanings:
         let inputString =
@@ -213,7 +213,7 @@ final class TextFormattingTests: XCTestCase {
     }
     
     func testEscapeOfBackslash() {
-        // Derived from CommonMark spec lines 533-537
+        // Derived from CommonMark spec lines 5558-5562
         // If a backslash is itself escaped, the following character is not:
         let inputString =
         #####"""
@@ -228,7 +228,7 @@ final class TextFormattingTests: XCTestCase {
     }
     
     func testCodeAreasPreserveBackslash() {
-        // Derived from CommonMark spec lines 569-576
+        // Derived from CommonMark spec lines 5594-5601
         // Backslash escapes do not work in code blocks
         let inputString =
         #####"""
@@ -246,7 +246,7 @@ final class TextFormattingTests: XCTestCase {
     }
     
     func testRawHTMLPreserveBackslash() {
-           // Derived from CommonMark spec lines 586-590
+           // Derived from CommonMark spec lines 5611-5615
            // Backslash escapes do not work in raw HTML
            let inputString =
            #####"""

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -216,6 +216,53 @@ final class TextFormattingTests: XCTestCase {
         """#####
         XCTAssertEqual(html, properAnswer)
     }
+    
+    func testCodeAreasPreserveBackslash() {
+        // Derived from CommonMark spec lines 569-576
+        // Backslash escapes do not work in code blocks
+        let inputString =
+        #####"""
+        ```
+        \[\]
+        ```
+        """#####
+        let html = MarkdownParser().html(from: inputString)
+        
+        let properAnswer = #####"""
+        <pre><code>\[\]</code></pre>
+        """#####
+        XCTAssertEqual(html, properAnswer)
+    }
+    
+    func testRawHTMLPreserveBackslash() {
+           // Derived from CommonMark spec lines 586-590
+           // Backslash escapes do not work in raw HTML
+           let inputString =
+           #####"""
+           <a href="/bar\/)">
+           """#####
+           let html = MarkdownParser().html(from: inputString)
+           
+           let properAnswer = #####"""
+           <a href="/bar\/)">
+           """#####
+           XCTAssertEqual(html, properAnswer)
+       }
+    
+    func testBackslashInURL() {
+        // Derived from CommonMark spec lines 596-600
+        // Backslash work in all other contexts, including URLs
+        let inputString =
+        #####"""
+        [foo](/bar\* "ti\*tle")
+        """#####
+        let html = MarkdownParser().html(from: inputString)
+        
+        let properAnswer = #####"""
+        <p><a href="/bar*" title="ti*tle">foo</a></p>
+        """#####
+        XCTAssertEqual(html, properAnswer)
+    }
 }
 
 extension TextFormattingTests {
@@ -250,7 +297,10 @@ extension TextFormattingTests {
             ("testEscapedPunctuation", testEscapedPunctuation),
             ("testOtherCharactersNotEscaped", testOtherCharactersNotEscaped),
             ("testEscapesThatOverrideMarkdown", testEscapesThatOverrideMarkdown),
-            ("testEscapeOfBackslash", testEscapeOfBackslash)
+            ("testEscapeOfBackslash", testEscapeOfBackslash),
+            ("testCodeAreasPreserveBackslash", testCodeAreasPreserveBackslash),
+            ("testRawHTMLPreserveBackslash", testRawHTMLPreserveBackslash),
+            ("testBackslashInURL", testBackslashInURL)
         ]
     }
 }

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -3,7 +3,11 @@
 *  Copyright (c) John Sundell 2019
 *  MIT license, see LICENSE file for details
 */
-
+// Some test are from a markdown spec with different licensing
+// title: GitHub Flavored Markdown Spec
+// version: 0.29
+// date: '2019-04-06'
+// license: '[CC-BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/)'
 import XCTest
 import Ink
 
@@ -160,7 +164,8 @@ final class TextFormattingTests: XCTestCase {
     }
     
     func testEscapedPunctuation() {
-        // Derived from CommonMark spec lines 5513-5517
+        // Derived from GitHub Flavored Markdown Spec lines 5794-5798
+        // Any ASCII punctuation character may be backslash-escaped:
         let allTheSpecialASCIIChars =
         #####"""
         \!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~
@@ -174,8 +179,10 @@ final class TextFormattingTests: XCTestCase {
     }
     
     func testOtherCharactersNotEscaped() {
-        // Derived from CommonMark spec lines 5523-5527
+        // Derived from GitHub Flavored Markdown Spec lines 5804-5808
         // watch out as there are tab characters in this test \#####t
+        // Backslashes before other characters are treated as literal
+        // backslashes:
         let inputString =
         #####"""
         \\#####t\A\a\ \3\φ\«
@@ -189,7 +196,7 @@ final class TextFormattingTests: XCTestCase {
     }
     
     func testEscapesThatOverrideMarkdown() {
-        // Derived from CommonMark spec lines 5533-5553
+        // Derived from GitHub Flavored Markdown Spec lines 5814-5834
         // Escaped characters are treated as regular characters and do
         // not have their usual Markdown meanings:
         let inputString =
@@ -213,7 +220,7 @@ final class TextFormattingTests: XCTestCase {
     }
     
     func testEscapeOfBackslash() {
-        // Derived from CommonMark spec lines 5558-5562
+        // Derived from GitHub Flavored Markdown Spec lines 5839-5843
         // If a backslash is itself escaped, the following character is not:
         let inputString =
         #####"""
@@ -228,8 +235,9 @@ final class TextFormattingTests: XCTestCase {
     }
     
     func testCodeAreasPreserveBackslash() {
-        // Derived from CommonMark spec lines 5594-5601
-        // Backslash escapes do not work in code blocks
+        // Derived from GitHub Flavored Markdown Spec lines 5860-5864
+        // Backslash escapes do not work in code blocks, code spans, autolinks, or
+        // raw HTML:
         let inputString =
         #####"""
         ```
@@ -246,7 +254,7 @@ final class TextFormattingTests: XCTestCase {
     }
     
     func testRawHTMLPreserveBackslash() {
-           // Derived from CommonMark spec lines 5611-5615
+           // Derived from GitHub Flavored Markdown Spec lines 5892-5896
            // Backslash escapes do not work in raw HTML
            let inputString =
            #####"""
@@ -261,7 +269,7 @@ final class TextFormattingTests: XCTestCase {
        }
 
     func testNullCharacterIsEscapedToHexFFFD() {
-        // Derived from CommonMark spec lines 494-495
+        // Derived from GitHub Flavored Markdown Spec lines 494-495
         // For security reasons, the Unicode character `U+0000` must be replaced
         // with the REPLACEMENT CHARACTER (`U+FFFD`).
         var inputString =
@@ -271,7 +279,7 @@ final class TextFormattingTests: XCTestCase {
         > a blockquote `code span`
 
         - list item
-        ```
+        ``` swift
         code block Here
         ```
         **bad Bold Text*
@@ -285,14 +293,18 @@ final class TextFormattingTests: XCTestCase {
         inputString.insert(null, at: inputString.firstIndex(of: "q")!)
         inputString.insert(null, at: inputString.firstIndex(of: "d")!)
         inputString.insert(null, at: inputString.firstIndex(of: "i")!)
+        inputString.insert(null, at: inputString.firstIndex(of: "w")!)
         inputString.insert(null, at: inputString.firstIndex(of: "H")!)
         inputString.insert(null, at: inputString.firstIndex(of: "*")!)
         inputString.insert(null, at: inputString.firstIndex(of: "#")!)
         
         let html = MarkdownParser().html(from: inputString)
         
+        // This test answer may fail when other code areas change.
+        // Make sure the nulls are still escaped and then paste the xctest into the following
+        // properAnswer field to get this test to pass.
         let properAnswer = #####"""
-        <p>A para�graph.</p><blockquote><p>a block�quote <code>co�de span</code></p></blockquote><ul><li>l�ist item <code></code>` code block �Here <code></code>` �*<em>bad Bold Text</em> �##bad heading</li></ul>
+        <p>A para�graph.</p><blockquote><p>a block�quote <code>co�de span</code></p></blockquote><ul><li>l�ist item <code></code>` s�wift code block �Here <code></code>` �*<em>bad Bold Text</em> �##bad heading</li></ul>
         """#####
         XCTAssertEqual(html, properAnswer)
     }

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -249,21 +249,7 @@ final class TextFormattingTests: XCTestCase {
            """#####
            XCTAssertEqual(html, properAnswer)
        }
-    
-    func testBackslashInURL() {
-        // Derived from CommonMark spec lines 596-600
-        // Backslash work in all other contexts, including URLs
-        let inputString =
-        #####"""
-        [foo](/bar\* "ti\*tle")
-        """#####
-        let html = MarkdownParser().html(from: inputString)
-        
-        let properAnswer = #####"""
-        <p><a href="/bar*" title="ti*tle">foo</a></p>
-        """#####
-        XCTAssertEqual(html, properAnswer)
-    }
+
 }
 
 extension TextFormattingTests {
@@ -300,8 +286,7 @@ extension TextFormattingTests {
             ("testEscapesThatOverrideMarkdown", testEscapesThatOverrideMarkdown),
             ("testEscapeOfBackslash", testEscapeOfBackslash),
             ("testCodeAreasPreserveBackslash", testCodeAreasPreserveBackslash),
-            ("testRawHTMLPreserveBackslash", testRawHTMLPreserveBackslash),
-            ("testBackslashInURL", testBackslashInURL)
+            ("testRawHTMLPreserveBackslash", testRawHTMLPreserveBackslash)            
         ]
     }
 }


### PR DESCRIPTION
Reworked a lot of backslash handling for CommonMark spec conformance.

I am leaving a breaking test with escapes in a URL that requires discussion on what to do with this case of escaped text with a context like URL.  The reader cannot be advanced as in the existing code since the backslash escapes can change length of substring. 

~I also have not researched if "\<" in this context becomes "<" or "$lt;"~

I have added the CommonMark URL escape as implemented by cMark.