### PR TITLE
Add "language-" to code class attribute

### DIFF
--- a/Sources/Ink/Internal/CodeBlock.swift
+++ b/Sources/Ink/Internal/CodeBlock.swift
@@ -48,7 +48,7 @@ internal struct CodeBlock: Fragment {
 
     func html(usingURLs urls: NamedURLCollection,
               modifiers: ModifierCollection) -> String {
-        let languageClass = language.isEmpty ? "" : " class=\"\(language)\""
+        let languageClass = language.isEmpty ? "" : " class=\"language-\(language)\""
         return "<pre><code\(languageClass)>\(code)</code></pre>"
     }
 }

--- a/Tests/InkTests/CodeTests.swift
+++ b/Tests/InkTests/CodeTests.swift
@@ -31,7 +31,7 @@ final class CodeTests: XCTestCase {
         ```
         """)
 
-        XCTAssertEqual(html, "<pre><code class=\"swift\">code()\n</code></pre>")
+        XCTAssertEqual(html, "<pre><code class=\"language-swift\">code()\n</code></pre>")
     }
     
     func testCodeBlockWithBackticksAndLabelNeedingTrimming() {
@@ -42,7 +42,7 @@ final class CodeTests: XCTestCase {
        ```
        """)
 
-       XCTAssertEqual(html, "<pre><code class=\"swift\">code()\n</code></pre>")
+       XCTAssertEqual(html, "<pre><code class=\"language-swift\">code()\n</code></pre>")
    }
     
     func testCodeBlockManyBackticks() {
@@ -54,7 +54,7 @@ final class CodeTests: XCTestCase {
         ````````````````````````````````
         """)
 
-        XCTAssertEqual(html, "<pre><code class=\"foo\">bar\n</code></pre>")
+        XCTAssertEqual(html, "<pre><code class=\"language-foo\">bar\n</code></pre>")
     }
     
     func testEncodingSpecialCharactersWithinCodeBlock() {
@@ -65,7 +65,7 @@ final class CodeTests: XCTestCase {
         """)
 
         XCTAssertEqual(html, """
-        <pre><code class="swift">Generic&lt;T&gt;() &amp;&amp; expression()\n</code></pre>
+        <pre><code class="language-swift">Generic&lt;T&gt;() &amp;&amp; expression()\n</code></pre>
         """)
     }
 


### PR DESCRIPTION
Both the HTML and CommonMark specs prefer <code class="language-swift"> to <code class="swift">. Changed HTML generation and tests to reflect this.