### PR TITLE
Unify whitespace trimming

### DIFF
--- a/Sources/Ink/Internal/CodeBlock.swift
+++ b/Sources/Ink/Internal/CodeBlock.swift
@@ -16,10 +16,11 @@ internal struct CodeBlock: Fragment {
         let startingMarkerCount = reader.readCount(of: marker)
         try require(startingMarkerCount >= 3)
         reader.discardWhitespaces()
-        var language = reader.readUntilEndOfLine()
-        while language.last?.isWhitespace == true {
-            language = language.dropLast()
-        }
+
+        let language = reader
+            .readUntilEndOfLine()
+            .trimmingTrailingWhitespaces()
+
         var code = ""
 
         while !reader.didReachEnd {
@@ -30,7 +31,7 @@ internal struct CodeBlock: Fragment {
                     break
                 } else {
                     code.append(String(repeating: marker, count: markerCount))
-                    if reader.didReachEnd { break } //maybe are at end of file? break for now?
+                    guard !reader.didReachEnd else { break }
                 }
             }
 

--- a/Sources/Ink/Internal/FormattedText.swift
+++ b/Sources/Ink/Internal/FormattedText.swift
@@ -176,9 +176,7 @@ private extension FormattedText {
             var string = reader.characters(in: endingTextRange)
 
             if trimWhitespaces {
-                while string.last?.isWhitespace == true {
-                    string = string.dropLast()
-                }
+                string = string.trimmingTrailingWhitespaces()
             }
 
             text.components.append(.text(string))

--- a/Sources/Ink/Internal/Metadata.swift
+++ b/Sources/Ink/Internal/Metadata.swift
@@ -46,16 +46,9 @@ internal struct Metadata: Readable {
 
 private extension Metadata {
     static func trim(_ string: Substring) -> String {
-        var string = string
-
-        while string.first?.isWhitespace == true {
-            string = string.dropFirst()
-        }
-
-        while string.last?.isWhitespace == true {
-            string = string.dropLast()
-        }
-
-        return String(string)
+        String(string
+            .trimmingLeadingWhitespaces()
+            .trimmingTrailingWhitespaces()
+        )
     }
 }

--- a/Sources/Ink/Internal/Reader.swift
+++ b/Sources/Ink/Internal/Reader.swift
@@ -134,7 +134,7 @@ extension Reader {
     
     mutating func discardWhitespaces() {
         while !didReachEnd {
-            guard !currentCharacter.isNewline && currentCharacter.isWhitespace else { return }
+            guard currentCharacter.isSameLineWhitespace else { return }
             advanceIndex()
         }
     }

--- a/Sources/Ink/Internal/Substring+Trimming.swift
+++ b/Sources/Ink/Internal/Substring+Trimming.swift
@@ -1,0 +1,21 @@
+/**
+*  Ink
+*  Copyright (c) John Sundell 2019
+*  MIT license, see LICENSE file for details
+*/
+
+internal extension Substring {
+    func trimmingLeadingWhitespaces() -> Self {
+        drop(while: { $0.isWhitespace })
+    }
+
+    func trimmingTrailingWhitespaces() -> Self {
+        var trimmed = self
+
+        while trimmed.last?.isWhitespace == true {
+            trimmed = trimmed.dropLast()
+        }
+
+        return trimmed
+    }
+}


### PR DESCRIPTION
Currently, there were several implementations of trimming leading/trailing whitespace from a substring, so this patch normalizes all of those into one extension on `Substring`. Also a slight tweak to `Reader` to use the `isSameLineWhitespace` API.