### PR TITLE
Process Unicode scalar values over 255 to HTML entities

### DIFF
--- a/Sources/Ink/Internal/Character+Escaping.swift
+++ b/Sources/Ink/Internal/Character+Escaping.swift
@@ -10,7 +10,13 @@ internal extension Character {
         case ">": return "&gt;"
         case "<": return "&lt;"
         case "&": return "&amp;"
-        default: return nil
+        default:
+            guard let unicodeScalar = self.unicodeScalars.first?.value else { return nil }
+            if unicodeScalar > 255 {
+                return "&#\(unicodeScalar);"
+            } else {
+                return nil
+            }
         }
     }
 }

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -113,6 +113,11 @@ final class TextFormattingTests: XCTestCase {
         XCTAssertEqual(html, "<p>Hello &lt; World &amp; &gt;</p>")
     }
 
+    func testEncodingTwoByteCharacters() {
+        let html = MarkdownParser().html(from: "Apostrophe ʼ .. em dash — ..")
+        XCTAssertEqual(html, "<p>Apostrophe &#700; .. em dash &#8212; ..</p>")
+    }
+
     func testSingleLineBlockquote() {
         let html = MarkdownParser().html(from: "> Hello, world!")
         XCTAssertEqual(html, "<blockquote><p>Hello, world!</p></blockquote>")
@@ -174,6 +179,7 @@ extension TextFormattingTests {
             ("testSingleTildeWithinStrikethroughText", testSingleTildeWithinStrikethroughText),
             ("testUnterminatedStrikethroughMarker", testUnterminatedStrikethroughMarker),
             ("testEncodingSpecialCharacters", testEncodingSpecialCharacters),
+            ("testEncodingTwoByteCharacters", testEncodingTwoByteCharacters),
             ("testSingleLineBlockquote", testSingleLineBlockquote),
             ("testMultiLineBlockquote", testMultiLineBlockquote),
             ("testEscapingSymbolsWithBackslash", testEscapingSymbolsWithBackslash),


### PR DESCRIPTION
Characters which are not in the single byte Unicode range are not rendered properly in the output generated by Ink.  Characters like em dash (used in the Ink `README.md` file) are passed through unchanged to the output HTML.  There may be browser settings to cope with such extended graphemes but Safari, by default, does not.

This code intercepts such characters and converts them to HTML entities so an em dash, for example, is converted to `&#8212`.  I'm far from certain that I put that intercept in an optimal place, and is a pretty brute-force approach, but I'm sure discussion here will improve that.

Note the correct rendering of a line from the Ink README:

<img width="672" alt="Ink+Unicode" src="https://user-images.githubusercontent.com/343117/70498848-b7b2c200-1ae5-11ea-9303-08e44a8fbb29.png">
