### PR TITLE
Metadata at beginning

### DIFF
--- a/Sources/Ink/Internal/Metadata.swift
+++ b/Sources/Ink/Internal/Metadata.swift
@@ -6,14 +6,62 @@
 
 internal struct Metadata: Readable {
     var values = [String : String]()
-
+    enum  YamlStyle {
+        /// use this case when no active key yet
+        case nokey
+        /// default, can also be started with ">"
+        case folded
+        /// to preserve newlines and space, can be started with "|"
+        case block
+        /// allows escaping
+        case doublequoted
+        /// no escaping needed
+        case singlequoted
+    }
     static func read(using reader: inout Reader) throws -> Metadata {
         try require(reader.readCount(of: "-") == 3)
         try reader.read("\n")
 
         var metadata = Metadata()
         var lastKey: String?
+        var currentStyle: YamlStyle = .nokey
+        var firstIndentDepth: Int = 0
         var linesSinceLastKey: Int = 0  // check for runaway parsing before reading to the end of file
+        
+        func unparsedWarning(warning: String, contents: String){
+            // A future list of parse warnings with line number
+            // this is a bit tricky because you only want to report error on a successful element
+        }
+        func addToKey(_ str: String, separator: String = " "){
+            if let theKey = lastKey {
+                if let val = metadata.values[theKey] {
+                    if val.isEmpty {
+                        metadata.values[theKey] = str
+                    } else {
+                        metadata.values[theKey]?.append(separator + str)
+                    }
+                } else {
+                    metadata.values[theKey] = str
+                }
+            }
+        }
+        
+        func processQuoteString(_ str: String) {
+            if currentStyle == .doublequoted && str.hasSuffix("\"") { // double quoted item on same line
+                let value = String(str.dropLast())
+                // need to process escapes here before storing
+                currentStyle = .nokey
+                addToKey(value, separator: " ")
+            } else if currentStyle == .singlequoted && str.hasSuffix("'") { // single quoted item on same line
+                let value = String(str.dropLast())
+                currentStyle = .nokey
+                addToKey(value, separator: " ")
+            } else {
+                addToKey(str, separator: " ")
+            }
+        }
+        
+        
         while !reader.didReachEnd && linesSinceLastKey < 25 {
             let line = reader.readUntilEndOfLine()
             
@@ -27,45 +75,101 @@ internal struct Metadata: Readable {
                     }
                 }
                 linesSinceLastKey += 1
-                continue //make life easy for now empty lines discarded while processing
+                switch currentStyle {
+                case .nokey:
+                    unparsedWarning(warning: "Empty line in metadata ignored", contents: "\n")
+                case .folded, .block, .doublequoted, .singlequoted :
+                    addToKey("\n", separator: "\n")
+                }
+                continue
             }
             let lineAtFirstChar = line.trimmingLeadingWhitespaces()
             if lineAtFirstChar.hasPrefix("- ") { // this looks like a YAML array element
-                if let lastKey = lastKey { // we have a key to comma append array item.
+                switch currentStyle {
+                case .nokey:
+                    unparsedWarning(warning: "Item without a key", contents: String(lineAtFirstChar))
+                case .folded:
                     let arrayItem = lineAtFirstChar.dropFirst(2)  // dump the "- " leader
-                    if let val = metadata.values[lastKey], val.isEmpty {
-                        metadata.values[lastKey] = String(arrayItem) // don't add a comma if first item
-                    } else {
-                        metadata.values[lastKey]?.append("," + arrayItem)  // this could be empty but whatever
-                    }
+                    addToKey(String(arrayItem), separator: ",")
+                case .block:
+                    addToKey(String(line.dropFirst(firstIndentDepth)), separator: "\n") // need to drop initial indent
+                case .doublequoted, .singlequoted :
+                    processQuoteString(trim(lineAtFirstChar))
                 }
                 continue
             }
             let separatedLine = lineAtFirstChar.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
             if separatedLine.count == 0 || separatedLine[0].isEmpty { // we have no key or whitespace line
                 linesSinceLastKey += 1
-                continue // dump the line no reasonable thing to do
-            }
-            if separatedLine.count == 1 && !separatedLine[0].isEmpty { // we just have data
-                if let lastKey = lastKey { // add it to the last key string if we have one
-                    metadata.values[lastKey]?.append(" " + trim(separatedLine[0]))
+                switch currentStyle {
+                case .nokey:
+                    unparsedWarning(warning: "Empty line in metadata ignored", contents: "\n")
+                case .block:
+                    addToKey(String(line.dropFirst(firstIndentDepth)), separator: "\n") // need to drop initial indent
+                case .folded:
+                    addToKey(trim(lineAtFirstChar), separator: " ")
+                case .doublequoted, .singlequoted :
+                    processQuoteString(trim(lineAtFirstChar))
                 }
+                continue
+            }
+            if separatedLine.count == 1 && !separatedLine[0].isEmpty { // we just have data, no colon
                 linesSinceLastKey += 1
+                switch currentStyle {
+                case .nokey:
+                    unparsedWarning(warning: "Empty line in metadata ignored", contents: "\n")
+                case .block:
+                    addToKey(String(line.dropFirst(firstIndentDepth)), separator: "\n") // need to drop initial indent
+                case .folded:
+                    addToKey(trim(lineAtFirstChar), separator: " ")
+                case .doublequoted, .singlequoted :
+                    processQuoteString(trim(lineAtFirstChar))
+                }
                 continue
             }
             let key = trim(separatedLine[0])
             if !key.isEmpty { //we just have a key at least
+                // here we should evaluate the escapes in last doublequote
                 var value = trim(separatedLine[1])
-                if value.hasPrefix("[") && value.hasSuffix("]") {
-                    value.removeLast(1)
-                    value.removeFirst(1)
-                }
-                metadata.values[key] = value // if the second component is empty it will init key
+                let pre = value.prefix(1)
+                // should really not accept a key that exists but will let it add now?
                 lastKey = key
                 linesSinceLastKey = 0
-            } else {
-                linesSinceLastKey += 1  // hard to force here because whitespace is trimmed earlier - no code coverage
-            }
+                switch pre {
+                case "": //new key with no value on this line
+                    currentStyle = .folded
+                    addToKey("", separator: " ")
+                case ">":
+                    currentStyle = .folded
+                    value = String(value.dropFirst())
+                    addToKey(value, separator: " ")
+                case "|":
+                    currentStyle = .block
+                    value = String(value.dropFirst())
+                    addToKey(value, separator: "\n")
+                case "\"":
+                    currentStyle = .doublequoted
+                    value = String(value.dropFirst())
+                    processQuoteString(value)
+                case "'":
+                    currentStyle = .singlequoted
+                    value = String(value.dropFirst())
+                    processQuoteString(value)
+                    
+                case "[":
+                    value = String(value.dropFirst())
+                    if value.hasSuffix("]") { // single quoted item on same line
+                        value = String(value.dropLast())
+                        addToKey(value, separator: " ")
+                        currentStyle = .nokey
+                    }
+                    // do not handle this case if array not on same line, may need new yamlStyle to handle
+               default: // assume default mode
+                    currentStyle = .folded
+                    addToKey(value, separator: " ")
+                }
+                
+            } 
         }
 
         throw Reader.Error()

--- a/Sources/Ink/Internal/Metadata.swift
+++ b/Sources/Ink/Internal/Metadata.swift
@@ -13,30 +13,53 @@ internal struct Metadata: Readable {
 
         var metadata = Metadata()
         var lastKey: String?
-
-        while !reader.didReachEnd {
-            reader.discardWhitespacesAndNewlines()
-
-            guard reader.currentCharacter != "-" else {
-                try require(reader.readCount(of: "-") == 3)
-                return metadata
+        var linesSinceLastKey: Int = 0  // check for runaway parsing before reading to the end of file
+        while !reader.didReachEnd && linesSinceLastKey < 25 {
+            let line = reader.readUntilEndOfLine()
+            
+            guard line != "---" else {
+                return metadata // this is the expected end signal
             }
-
-            let key = try trim(reader.read(until: ":", required: false))
-
-            guard reader.previousCharacter == ":" else {
-                if let lastKey = lastKey {
-                    metadata.values[lastKey]?.append(" " + key)
+            if line.isEmpty {
+                if reader.didReachEnd { // empty because of file end
+                    if metadata.values.count > 0 {
+                        return metadata // case of good metadata but end of file reached first
+                    }
                 }
-
+                linesSinceLastKey += 1
+                continue //make life easy for now empty lines discarded while processing
+            }
+            let lineAtFirstChar = line.trimmingLeadingWhitespaces()
+            if lineAtFirstChar.hasPrefix("- ") { // this looks like a YAML array element
+                if let lastKey = lastKey { // we have a key to comma append array item.
+                    let arrayItem = lineAtFirstChar.dropFirst(2)  // dump the "- " leader
+                    if let val = metadata.values[lastKey], val.isEmpty {
+                        metadata.values[lastKey] = String(arrayItem) // don't add a comma if first item
+                    } else {
+                        metadata.values[lastKey]?.append("," + arrayItem)  // this could be empty but whatever
+                    }
+                }
                 continue
             }
-
-            let value = trim(reader.readUntilEndOfLine())
-
-            if !value.isEmpty {
-                metadata.values[key] = value
+            let separatedLine = lineAtFirstChar.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+            if separatedLine.count == 0 || separatedLine[0].isEmpty { // we have no key or whitespace line
+                linesSinceLastKey += 1
+                continue // dump the line no reasonable thing to do
+            }
+            if separatedLine.count == 1 && !separatedLine[0].isEmpty { // we just have data
+                if let lastKey = lastKey { // add it to the last key string if we have one
+                    metadata.values[lastKey]?.append(" " + trim(separatedLine[0]))
+                }
+                linesSinceLastKey += 1
+                continue
+            }
+            let key = trim(separatedLine[0])
+            if !key.isEmpty { //we just have a key at least
+                metadata.values[key] = trim(separatedLine[1]) // if the second component is empty it will init key
                 lastKey = key
+                linesSinceLastKey = 0
+            } else {
+                linesSinceLastKey += 1  // hard to force here because whitespace is trimmed earlier - no code coverage
             }
         }
 

--- a/Sources/Ink/Internal/Metadata.swift
+++ b/Sources/Ink/Internal/Metadata.swift
@@ -55,7 +55,12 @@ internal struct Metadata: Readable {
             }
             let key = trim(separatedLine[0])
             if !key.isEmpty { //we just have a key at least
-                metadata.values[key] = trim(separatedLine[1]) // if the second component is empty it will init key
+                var value = trim(separatedLine[1])
+                if value.hasPrefix("[") && value.hasSuffix("]") {
+                    value.removeLast(1)
+                    value.removeFirst(1)
+                }
+                metadata.values[key] = value // if the second component is empty it will init key
                 lastKey = key
                 linesSinceLastKey = 0
             } else {

--- a/Sources/Ink/Internal/Reader.swift
+++ b/Sources/Ink/Internal/Reader.swift
@@ -17,7 +17,7 @@ internal struct Reader {
 extension Reader {
     struct Error: Swift.Error {}
 
-    var didReachEnd: Bool { currentIndex == endIndex }
+    var didReachEnd: Bool { currentIndex >= endIndex } // in case it was advanced past end.
     var previousCharacter: Character? { lookBehindAtPreviousCharacter() }
     var currentCharacter: Character { string[currentIndex] }
     var nextCharacter: Character? { lookAheadAtNextCharacter() }

--- a/Tests/InkTests/MarkdownTests.swift
+++ b/Tests/InkTests/MarkdownTests.swift
@@ -77,6 +77,21 @@ final class MarkdownTests: XCTestCase {
         XCTAssertEqual(markdown.html, "<hr><h1>Title</h1>")
     }
 
+    func testMetadataInWrongPlace() {
+        let markdown = MarkdownParser().parse("""
+        # Title
+        ---
+        a: 1
+        b : 2
+        ---
+        ## Section
+        """)
+
+        XCTAssertEqual(markdown.metadata, [:])
+        // This test will start to fail if the --- can be interpreted as underlining changing the paragraph to a <h2>
+        // without underlining the second --- might be also an <hr> but the current parser is not looking out for ---
+        XCTAssertEqual(markdown.html, "<h1>Title</h1><hr><p>a: 1 b : 2 ---</p><h2>Section</h2>")
+    }
 
     func testPlainTextTitle() {
         let markdown = MarkdownParser().parse("""

--- a/Tests/InkTests/MarkdownTests.swift
+++ b/Tests/InkTests/MarkdownTests.swift
@@ -142,6 +142,7 @@ extension MarkdownTests {
             ("testMergingOrphanMetadataValueIntoPreviousOne", testMergingOrphanMetadataValueIntoPreviousOne),
             ("testMissingMetadata", testMissingMetadata),
             ("testStartWithRule", testStartWithRule),
+            ("testMetadataInWrongPlace", testMetadataInWrongPlace),
             ("testPlainTextTitle", testPlainTextTitle),
             ("testRemovingTrailingMarkersFromTitle", testRemovingTrailingMarkersFromTitle),
             ("testConvertingFormattedTitleTextToPlainText", testConvertingFormattedTitleTextToPlainText),

--- a/Tests/InkTests/MarkdownTests.swift
+++ b/Tests/InkTests/MarkdownTests.swift
@@ -127,9 +127,67 @@ final class MarkdownTests: XCTestCase {
         # Title
         """)
 
-        XCTAssertEqual(markdown.metadata, ["draft": "false", "lastmod": "\'2017-11-24T15:15:52-05:00\'", "description": "Privacy statement for --- Website Inc.", "nobc": "true", "tags": "", "keywords": "Website Inc.,privacy,gdpr", "date": "\'2018-11-19T13:10:52-05:00\'", "type": "webpage", "language": "en", "title": "Privacy"])
+        XCTAssertEqual(markdown.metadata, ["tags": "", "language": "en", "draft": "false", "keywords": "Website Inc.,privacy,gdpr", "date": "2018-11-19T13:10:52-05:00", "type": "webpage", "nobc": "true", "lastmod": "2017-11-24T15:15:52-05:00", "title": "Privacy", "description": "Privacy statement for --- Website Inc."])
         XCTAssertEqual(markdown.html, "<h1>Title</h1>")
     }
+    
+    func testMoreYAMLLikeMetadata() {
+           let markdown = MarkdownParser().parse("""
+           ---
+           draft: false
+           title: Privacy
+           description: >
+             Privacy statement for --- Website Inc.
+           language: en
+           wordsofwisdom: "We need to
+            test the long sentences
+            also"
+           keywords:
+             - Website Inc.
+             - privacy
+             - gdpr
+           date: '2018-11-19T13:10:52-05:00'
+           lastmod: '2017-11-24T15:15:52-05:00'
+           type: "webpage"
+           nobc: true
+           ---
+           # Title
+           """)
+
+           XCTAssertEqual(markdown.metadata, ["lastmod": "2017-11-24T15:15:52-05:00", "type": "webpage", "nobc": "true", "draft": "false", "keywords": "Website Inc.,privacy,gdpr", "date": "2018-11-19T13:10:52-05:00", "title": "Privacy", "description": "Privacy statement for --- Website Inc.", "wordsofwisdom": "We need to test the long sentences also", "language": "en"])
+           XCTAssertEqual(markdown.html, "<h1>Title</h1>")
+       }
+    
+    func testBadYAMLLikeMetadata() {
+              let markdown = MarkdownParser().parse("""
+              ---
+               - item before key
+                : no key
+
+              title: |
+                The best
+                - awesome -
+                Web Publisher
+                : The Sequel
+                   
+              description: >
+                Privacy statement for
+                     
+                --- Website Inc.
+              language: en
+              wordsofwisdom: "We need to
+                - handle asides in -
+               test the long sentences
+
+                    :hi:
+               also"
+              ---
+              # Title
+              """)
+
+              XCTAssertEqual(markdown.metadata, ["title": "  The best\n  - awesome -\n  Web Publisher\n  : The Sequel\n     ", "wordsofwisdom": "We need to - handle asides in - test the long sentences\n\n :hi: also", "language": "en", "description": "Privacy statement for  --- Website Inc."])
+              XCTAssertEqual(markdown.html, "<h1>Title</h1>")
+          }
     
     func testJustMetadata() {
         let markdown = MarkdownParser().parse("""
@@ -231,6 +289,8 @@ extension MarkdownTests {
             ("testMissingMetadata", testMissingMetadata),
             ("testFalseMetadata", testFalseMetadata),
             ("testYAMLLikeMetadata", testYAMLLikeMetadata),
+            ("testMoreYAMLLikeMetadata", testMoreYAMLLikeMetadata),
+            ("testBadYAMLLikeMetadata", testBadYAMLLikeMetadata),
             ("testJustMetadata", testJustMetadata),
             ("testStartWithRuleAndOtherNonMetaData", testStartWithRuleAndOtherNonMetaData),
             ("testStartWithRule", testStartWithRule),

--- a/Tests/InkTests/MarkdownTests.swift
+++ b/Tests/InkTests/MarkdownTests.swift
@@ -66,6 +66,17 @@ final class MarkdownTests: XCTestCase {
         XCTAssertEqual(markdown.metadata, [:])
         XCTAssertEqual(markdown.html, "<h1>Title</h1>")
     }
+    
+    func testStartWithRule() {
+        let markdown = MarkdownParser().parse("""
+        ---
+        # Title
+        """)
+
+        XCTAssertEqual(markdown.metadata, [:])
+        XCTAssertEqual(markdown.html, "<hr><h1>Title</h1>")
+    }
+
 
     func testPlainTextTitle() {
         let markdown = MarkdownParser().parse("""
@@ -115,6 +126,7 @@ extension MarkdownTests {
             ("testDiscardingEmptyMetadataValues", testDiscardingEmptyMetadataValues),
             ("testMergingOrphanMetadataValueIntoPreviousOne", testMergingOrphanMetadataValueIntoPreviousOne),
             ("testMissingMetadata", testMissingMetadata),
+            ("testStartWithRule", testStartWithRule),
             ("testPlainTextTitle", testPlainTextTitle),
             ("testRemovingTrailingMarkersFromTitle", testRemovingTrailingMarkersFromTitle),
             ("testConvertingFormattedTitleTextToPlainText", testConvertingFormattedTitleTextToPlainText),

--- a/Tests/InkTests/MarkdownTests.swift
+++ b/Tests/InkTests/MarkdownTests.swift
@@ -127,7 +127,7 @@ final class MarkdownTests: XCTestCase {
         # Title
         """)
 
-        XCTAssertEqual(markdown.metadata, ["date": "\'2018-11-19T13:10:52-05:00\'", "nobc": "true", "draft": "false", "language": "en", "description": "Privacy statement for --- Website Inc.", "lastmod": "\'2017-11-24T15:15:52-05:00\'", "type": "webpage", "tags": "[]", "keywords": "Website Inc.,privacy,gdpr", "title": "Privacy"])
+        XCTAssertEqual(markdown.metadata, ["draft": "false", "lastmod": "\'2017-11-24T15:15:52-05:00\'", "description": "Privacy statement for --- Website Inc.", "nobc": "true", "tags": "", "keywords": "Website Inc.,privacy,gdpr", "date": "\'2018-11-19T13:10:52-05:00\'", "type": "webpage", "language": "en", "title": "Privacy"])
         XCTAssertEqual(markdown.html, "<h1>Title</h1>")
     }
     


### PR DESCRIPTION
Moved the metadata parse to be only once at the beginning of the markdown file.

This will make the inner loop  slightly faster by not doing the meta check. I think in the future there may be a desire to have different metadata parsers and moving it out of the main loop might make it a little easier to have a separate optional system for metadata.