### PR TITLE
Added correct MacOS minimum deployment version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,9 @@ import PackageDescription
 
 let package = Package(
     name: "Ink",
+    platforms: [
+        .macOS(.v10_15),
+    ],
     products: [
         .library(name: "Ink", targets: ["Ink"]),
         .executable(name: "ink-cli", targets: ["InkCLI"])


### PR DESCRIPTION
I tried to run `Ink` as a dependency of one of my package, but when running on MacOS Mojave (10.14.x), the executable crashes with the following error:

```
dyld: Library not loaded: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/Ink.framework/Versions/A/Ink
  Referenced from: /System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/HIToolbox
  Reason: Incompatible library version: HIToolbox requires version 1.0.0 or later, but Ink provides version 0.0.0
Program ended with exit code: 9
```

It seems that `Carbon.framework` has a framework named `Ink` which conflicts with this one. Probably this doesn't happen on MacOS Catalina because the `Ink.framework` seems to be deprecated and (maybe) removed in Catalina (see [Deprecations](https://developer.apple.com/documentation/macos_release_notes/macos_mojave_10_14_release_notes?language=objc)). Unfortunately I cannot confirm because I'm running only on MacOS Mojave 10.14.6.

If this is valid, would it make sense to specify the minimum deployment version to Catalina? It would save some time to Mojave users.