### PR TITLE
Make Reader public

### DIFF
--- a/Sources/Ink/API/Reader.swift
+++ b/Sources/Ink/API/Reader.swift
@@ -4,17 +4,17 @@
 *  MIT license, see LICENSE file for details
 */
 
-internal struct Reader {
+public struct Reader {
     private let string: String
     private(set) var currentIndex: String.Index
 
-    init(string: String) {
+    public init(string: String) {
         self.string = string
         self.currentIndex = string.startIndex
     }
 }
 
-extension Reader {
+public extension Reader {
     struct Error: Swift.Error {}
 
     var didReachEnd: Bool { currentIndex == endIndex }
@@ -159,7 +159,7 @@ extension Reader {
     }
 }
 
-private extension Reader {
+public extension Reader {
     func lookBehindAtPreviousCharacter() -> Character? {
         guard currentIndex != string.startIndex else { return nil }
         let previousIndex = string.index(before: currentIndex)


### PR DESCRIPTION
You provide us with a method to modify how html is generated from markdown with the `MarkdownParser.addModifier` function. But then you don't provide us with any of the tools you have written to parse the markdown. I could re-implement the Reader class in my own code but seems it would be more sensible to use what is already there.
