### PR TITLE
Enable metadata keys and values to be modified

### DIFF
--- a/Sources/Ink/API/MarkdownParser.swift
+++ b/Sources/Ink/API/MarkdownParser.swift
@@ -53,7 +53,7 @@ public struct MarkdownParser {
             do {
                 if metadata == nil, fragments.isEmpty, reader.currentCharacter == "-" {
                     if let parsedMetadata = try? Metadata.readOrRewind(using: &reader) {
-                        metadata = parsedMetadata
+                        metadata = parsedMetadata.applyingModifiers(modifiers)
                         continue
                     }
                 }

--- a/Sources/Ink/API/Modifier.swift
+++ b/Sources/Ink/API/Modifier.swift
@@ -16,7 +16,8 @@
 public struct Modifier {
     /// The type of input that each modifier is given, which both
     /// contains the HTML that was generated for a fragment, and
-    /// its raw Markdown representation.
+    /// its raw Markdown representation. Note that for metadata
+    /// targets, the two input arguments will be equivalent.
     public typealias Input = (html: String, markdown: Substring)
     /// The type of closure that Modifiers are based on. Each
     /// modifier is given a set of input, and is expected to return
@@ -39,6 +40,8 @@ public struct Modifier {
 
 public extension Modifier {
     enum Target {
+        case metadataKeys
+        case metadataValues
         case blockquotes
         case codeBlocks
         case headings

--- a/Sources/Ink/Internal/Metadata.swift
+++ b/Sources/Ink/Internal/Metadata.swift
@@ -42,6 +42,26 @@ internal struct Metadata: Readable {
 
         throw Reader.Error()
     }
+
+    func applyingModifiers(_ modifiers: ModifierCollection) -> Self {
+        var modified = self
+
+        modifiers.applyModifiers(for: .metadataKeys) { modifier in
+            for (key, value) in modified.values {
+                let newKey = modifier.closure((key, Substring(key)))
+                modified.values[key] = nil
+                modified.values[newKey] = value
+            }
+        }
+
+        modifiers.applyModifiers(for: .metadataValues) { modifier in
+            modified.values = modified.values.mapValues { value in
+                modifier.closure((value, Substring(value)))
+            }
+        }
+
+        return modified
+    }
 }
 
 private extension Metadata {

--- a/Tests/InkTests/MarkdownTests.swift
+++ b/Tests/InkTests/MarkdownTests.swift
@@ -67,6 +67,29 @@ final class MarkdownTests: XCTestCase {
         XCTAssertEqual(markdown.html, "<h1>Title</h1>")
     }
 
+    func testMetadataModifiers() {
+        let parser = MarkdownParser(modifiers: [
+            Modifier(target: .metadataKeys) { key, _ in
+                "ModifiedKey-" + key
+            },
+            Modifier(target: .metadataValues) { value, _ in
+                "ModifiedValue-" + value
+            }
+        ])
+
+        let markdown = parser.parse("""
+        ---
+        keyA: valueA
+        keyB: valueB
+        ---
+        """)
+
+        XCTAssertEqual(markdown.metadata, [
+            "ModifiedKey-keyA" : "ModifiedValue-valueA",
+            "ModifiedKey-keyB" : "ModifiedValue-valueB"
+        ])
+    }
+
     func testPlainTextTitle() {
         let markdown = MarkdownParser().parse("""
         # Hello, world!
@@ -115,6 +138,7 @@ extension MarkdownTests {
             ("testDiscardingEmptyMetadataValues", testDiscardingEmptyMetadataValues),
             ("testMergingOrphanMetadataValueIntoPreviousOne", testMergingOrphanMetadataValueIntoPreviousOne),
             ("testMissingMetadata", testMissingMetadata),
+            ("testMetadataModifiers", testMetadataModifiers),
             ("testPlainTextTitle", testPlainTextTitle),
             ("testRemovingTrailingMarkersFromTitle", testRemovingTrailingMarkersFromTitle),
             ("testConvertingFormattedTitleTextToPlainText", testConvertingFormattedTitleTextToPlainText),


### PR DESCRIPTION
This change introduces two new `Modifier.Target` instances: `metadataKeys` and `metadataValues`, which can be used to customize how Ink parses metadata. This in turn enables Publish plugins to be written that bridges the gap between Publish’s built-in metadata format and that of external tools, such as other static site generators or CMSs.