### PR TITLE
Handle HTML entities

### DIFF
--- a/Sources/Ink/Internal/FormattedText.swift
+++ b/Sources/Ink/Internal/FormattedText.swift
@@ -199,12 +199,6 @@ private extension FormattedText {
         }
 
         private mutating func parseNonTriggeringCharacter() {
-            guard reader.currentCharacter != "\\" else {
-                addPendingTextIfNeeded()
-                skipCharacter()
-                return
-            }
-
             switch reader.currentCharacter {
             case "\\":
                 addPendingTextIfNeeded()

--- a/Sources/Ink/Internal/FormattedText.swift
+++ b/Sources/Ink/Internal/FormattedText.swift
@@ -205,12 +205,28 @@ private extension FormattedText {
                 return
             }
 
-            if let escaped = reader.currentCharacter.escaped {
+            switch reader.currentCharacter {
+            case "\\":
                 addPendingTextIfNeeded()
-                text.components.append(.text(Substring(escaped)))
                 skipCharacter()
-            } else {
-                reader.advanceIndex()
+            case "&":
+                let ampersandIndex = reader.currentIndex
+
+                do {
+                    try reader.read(until: ";", allowWhitespace: false)
+                    addPendingTextIfNeeded()
+                } catch {
+                    reader.moveToIndex(ampersandIndex)
+                    fallthrough
+                }
+            default:
+                if let escaped = reader.currentCharacter.escaped {
+                    addPendingTextIfNeeded()
+                    text.components.append(.text(Substring(escaped)))
+                    skipCharacter()
+                } else {
+                    reader.advanceIndex()
+                }
             }
         }
 

--- a/Sources/Ink/Internal/Reader.swift
+++ b/Sources/Ink/Internal/Reader.swift
@@ -36,6 +36,7 @@ extension Reader {
     @discardableResult
     mutating func read(until character: Character,
                        required: Bool = true,
+                       allowWhitespace: Bool = true,
                        allowLineBreaks: Bool = false) throws -> Substring {
         let startIndex = currentIndex
 
@@ -44,6 +45,10 @@ extension Reader {
                 let result = string[startIndex..<currentIndex]
                 advanceIndex()
                 return result
+            }
+
+            if !allowWhitespace, currentCharacter.isNewline {
+                break
             }
 
             if !allowLineBreaks, currentCharacter.isNewline {

--- a/Tests/InkTests/HTMLTests.swift
+++ b/Tests/InkTests/HTMLTests.swift
@@ -103,6 +103,14 @@ final class HTMLTests: XCTestCase {
 
         XCTAssertEqual(html, "<p>Hello</p><!-- Comment --><p>World</p>")
     }
+
+    func testHTMLEntities() {
+        let html = MarkdownParser().html(from: """
+        Hello &amp; welcome to &lt;Ink&gt;
+        """)
+
+        XCTAssertEqual(html, "<p>Hello &amp; welcome to &lt;Ink&gt;</p>")
+    }
 }
 
 extension HTMLTests {
@@ -118,7 +126,8 @@ extension HTMLTests {
             ("testTopLevelSelfClosingHTMLElement", testTopLevelSelfClosingHTMLElement),
             ("testInlineSelfClosingHTMLElement", testInlineSelfClosingHTMLElement),
             ("testTopLevelHTMLLineBreak", testTopLevelHTMLLineBreak),
-            ("testHTMLComment", testHTMLComment)
+            ("testHTMLComment", testHTMLComment),
+            ("testHTMLEntities", testHTMLEntities)
         ]
     }
 }


### PR DESCRIPTION
This patch makes Ink correctly handle raw HTML entities that appear inline within formatted text, such as `&amp;` and `&gt;`. Previously, an inline `&amp;` would be parsed as `&amp;amp;`.