### PR TITLE
Condition checked for newline instead of whitespaces in Reader.read(until ...)

### DIFF
--- a/Sources/Ink/Internal/Reader.swift
+++ b/Sources/Ink/Internal/Reader.swift
@@ -47,7 +47,7 @@ extension Reader {
                 return result
             }
 
-            if !allowWhitespace, currentCharacter.isNewline {
+            if !allowWhitespace, currentCharacter.isSameLineWhitespace {
                 break
             }
 


### PR DESCRIPTION
The read until character method in `Reader`
```swift
@discardableResult
mutating func read(until character: Character,
                   required: Bool = true,
                   allowWhitespace: Bool = true,
                   allowLineBreaks: Bool = false) throws -> Substring
```
checked for `currentCharacter.isNewline` instead of `currentCharacter.isSameLineWhitespace` if `allowWhitespace = false`.

This had no effect on functionality so far, but may be useful to fix for future additions to ink.