### PR TITLE
Support titles for links and images

### DIFF
--- a/Sources/Ink/API/MarkdownParser.swift
+++ b/Sources/Ink/API/MarkdownParser.swift
@@ -42,7 +42,7 @@ public struct MarkdownParser {
     public func parse(_ markdown: String) -> Markdown {
         var reader = Reader(string: markdown)
         var fragments = [ParsedFragment]()
-        var urlsByName = [String : URL]()
+        var urlsByName = [String : URLDeclaration]()
         var titleHeading: Heading?
         var metadata: Metadata?
 
@@ -60,7 +60,7 @@ public struct MarkdownParser {
 
                 guard reader.currentCharacter != "[" else {
                     let declaration = try URLDeclaration.readOrRewind(using: &reader)
-                    urlsByName[declaration.name] = declaration.url
+                    urlsByName[declaration.name] = declaration
                     continue
                 }
 

--- a/Sources/Ink/Internal/Character+Classification.swift
+++ b/Sources/Ink/Internal/Character+Classification.swift
@@ -9,13 +9,13 @@ internal extension Character {
         isWhitespace && !isNewline
     }
 
-	var isLegalInURL: Bool {
-		self != ")" && self != " "
-	}
+    var isLegalInURL: Bool {
+        self != ")" && self != " "
+    }
 
-	var isSameLineNonWhitespace: Bool {
-		!isWhitespace && !isNewline
-	}
+    var isSameLineNonWhitespace: Bool {
+        !isWhitespace && !isNewline
+    }
 }
 
 internal extension Set where Element == Character {
@@ -24,15 +24,15 @@ internal extension Set where Element == Character {
 }
 
 internal enum TitleDelimeter: Character {
-	case doubleQuote = "\""
-	case singleQuote = "'"
-	case parenthetical = "("
-	var closing: Character {
-		switch self {
-		case .parenthetical:
-			return ")"
-		default:
-			return self.rawValue
-		}
-	}
+    case doubleQuote = "\""
+    case singleQuote = "'"
+    case parenthetical = "("
+    var closing: Character {
+        switch self {
+        case .parenthetical:
+            return ")"
+        default:
+            return self.rawValue
+        }
+    }
 }

--- a/Sources/Ink/Internal/Character+Classification.swift
+++ b/Sources/Ink/Internal/Character+Classification.swift
@@ -8,9 +8,31 @@ internal extension Character {
     var isSameLineWhitespace: Bool {
         isWhitespace && !isNewline
     }
+
+	var isLegalInURL: Bool {
+		self != ")" && self != " "
+	}
+
+	var isSameLineNonWhitespace: Bool {
+		!isWhitespace && !isNewline
+	}
 }
 
 internal extension Set where Element == Character {
     static let boldItalicStyleMarkers: Self = ["*", "_"]
     static let allStyleMarkers: Self = boldItalicStyleMarkers.union(["~"])
+}
+
+internal enum TitleDelimeter: Character {
+	case doubleQuote = "\""
+	case singleQuote = "'"
+	case parenthetical = "("
+	var closing: Character {
+		switch self {
+		case .parenthetical:
+			return ")"
+		default:
+			return self.rawValue
+		}
+	}
 }

--- a/Sources/Ink/Internal/Image.swift
+++ b/Sources/Ink/Internal/Image.swift
@@ -23,10 +23,10 @@ internal struct Image: Fragment {
             alt = " alt=\"\(alt)\""
         }
 
-		var titleAttribute = ""
-		if let title = link.title {
-			titleAttribute = " title=\"\(title)\""
-		}
+        var titleAttribute = ""
+        if let title = link.title {
+            titleAttribute = " title=\"\(title)\""
+        }
 
         return "<img src=\"\(url)\"\(alt)\(titleAttribute)/>"
     }

--- a/Sources/Ink/Internal/Image.swift
+++ b/Sources/Ink/Internal/Image.swift
@@ -23,7 +23,12 @@ internal struct Image: Fragment {
             alt = " alt=\"\(alt)\""
         }
 
-        return "<img src=\"\(url)\"\(alt)/>"
+		var titleAttribute = ""
+		if let title = link.title {
+			titleAttribute = " title=\"\(title)\""
+		}
+
+        return "<img src=\"\(url)\"\(alt)\(titleAttribute)/>"
     }
 
     func plainText() -> String {

--- a/Sources/Ink/Internal/Link.swift
+++ b/Sources/Ink/Internal/Link.swift
@@ -9,7 +9,7 @@ internal struct Link: Fragment {
 
     var target: Target
     var text: FormattedText
-	var title: Substring?
+    var title: Substring?
 
     static func read(using reader: inout Reader) throws -> Link {
         try reader.read("[")
@@ -20,16 +20,16 @@ internal struct Link: Fragment {
 
         if reader.currentCharacter == "(" {
             reader.advanceIndex()
-			let url = try reader.readCharacters(matching: \.isLegalInURL)
+            let url = try reader.readCharacters(matching: \.isLegalInURL)
 
-			guard !reader.didReachEnd else { throw Reader.Error() }
-			var titleText: Substring? = nil
-			if reader.currentCharacter.isSameLineWhitespace {
-				try reader.readWhitespaces()
-				try reader.read("\"")
-				titleText = try reader.read(until: "\"")
-			}
-			try reader.read(")")
+            guard !reader.didReachEnd else { throw Reader.Error() }
+            var titleText: Substring? = nil
+            if reader.currentCharacter.isSameLineWhitespace {
+                try reader.readWhitespaces()
+                try reader.read("\"")
+                titleText = try reader.read(until: "\"")
+            }
+            try reader.read(")")
             return Link(target: .url(url), text: text, title: titleText)
         } else {
             try reader.read("[")
@@ -41,13 +41,13 @@ internal struct Link: Fragment {
     func html(usingURLs urls: NamedURLCollection,
               modifiers: ModifierCollection) -> String {
         let url = target.url(from: urls)
-		let refTitle = target.title(from: urls)
+        let refTitle = target.title(from: urls)
         let linkText = text.html(usingURLs: urls, modifiers: modifiers)
-		let finalTitle = refTitle ?? title
-		var titleAttribute: String = ""
-		if let finalTitle = finalTitle {
-			titleAttribute = " title=\"\(finalTitle)\""
-		}
+        let finalTitle = refTitle ?? title
+        var titleAttribute: String = ""
+        if let finalTitle = finalTitle {
+            titleAttribute = " title=\"\(finalTitle)\""
+        }
         return "<a href=\"\(url)\"\(titleAttribute)>\(linkText)</a>"
     }
 
@@ -69,16 +69,16 @@ extension Link.Target {
         case .url(let url):
             return url
         case .reference(let name):
-			return urls.url(named: name)?.url ?? name
+            return urls.url(named: name)?.url ?? name
         }
     }
 
-	func title(from urls: NamedURLCollection) -> Substring? {
+    func title(from urls: NamedURLCollection) -> Substring? {
         switch self {
         case .url:
             return nil
         case .reference(let name):
-			return urls.url(named: name)?.title
+            return urls.url(named: name)?.title
         }
     }
 }

--- a/Sources/Ink/Internal/Link.swift
+++ b/Sources/Ink/Internal/Link.swift
@@ -9,6 +9,7 @@ internal struct Link: Fragment {
 
     var target: Target
     var text: FormattedText
+	var title: Substring?
 
     static func read(using reader: inout Reader) throws -> Link {
         try reader.read("[")
@@ -19,20 +20,35 @@ internal struct Link: Fragment {
 
         if reader.currentCharacter == "(" {
             reader.advanceIndex()
-            let url = try reader.read(until: ")")
-            return Link(target: .url(url), text: text)
+			let url = try reader.readCharacters(matching: \.isLegalInURL)
+
+			guard !reader.didReachEnd else { throw Reader.Error() }
+			var titleText: Substring? = nil
+			if reader.currentCharacter.isSameLineWhitespace {
+				try reader.readWhitespaces()
+				try reader.read("\"")
+				titleText = try reader.read(until: "\"")
+			}
+			try reader.read(")")
+            return Link(target: .url(url), text: text, title: titleText)
         } else {
             try reader.read("[")
             let reference = try reader.read(until: "]")
-            return Link(target: .reference(reference), text: text)
+            return Link(target: .reference(reference), text: text, title: nil)
         }
     }
 
     func html(usingURLs urls: NamedURLCollection,
               modifiers: ModifierCollection) -> String {
         let url = target.url(from: urls)
-        let title = text.html(usingURLs: urls, modifiers: modifiers)
-        return "<a href=\"\(url)\">\(title)</a>"
+		let refTitle = target.title(from: urls)
+        let linkText = text.html(usingURLs: urls, modifiers: modifiers)
+		let finalTitle = refTitle ?? title
+		var titleAttribute: String = ""
+		if let finalTitle = finalTitle {
+			titleAttribute = " title=\"\(finalTitle)\""
+		}
+        return "<a href=\"\(url)\"\(titleAttribute)>\(linkText)</a>"
     }
 
     func plainText() -> String {
@@ -53,7 +69,16 @@ extension Link.Target {
         case .url(let url):
             return url
         case .reference(let name):
-            return urls.url(named: name) ?? name
+			return urls.url(named: name)?.url ?? name
+        }
+    }
+
+	func title(from urls: NamedURLCollection) -> Substring? {
+        switch self {
+        case .url:
+            return nil
+        case .reference(let name):
+			return urls.url(named: name)?.title
         }
     }
 }

--- a/Sources/Ink/Internal/NamedURLCollection.swift
+++ b/Sources/Ink/Internal/NamedURLCollection.swift
@@ -5,13 +5,13 @@
 */
 
 internal struct NamedURLCollection {
-    private let urlsByName: [String : URL]
+    private let urlsByName: [String : URLDeclaration]
 
-    init(urlsByName: [String : URL]) {
+    init(urlsByName: [String : URLDeclaration]) {
         self.urlsByName = urlsByName
     }
 
-    func url(named name: Substring) -> URL? {
+    func url(named name: Substring) -> URLDeclaration? {
         urlsByName[name.lowercased()]
     }
 }

--- a/Sources/Ink/Internal/URLDeclaration.swift
+++ b/Sources/Ink/Internal/URLDeclaration.swift
@@ -7,14 +7,25 @@
 internal struct URLDeclaration: Readable {
     var name: String
     var url: URL
+	var title: Substring?
 
     static func read(using reader: inout Reader) throws -> Self {
         try reader.read("[")
         let name = try reader.read(until: "]")
         try reader.read(":")
         try reader.readWhitespaces()
-        let url = reader.readUntilEndOfLine()
 
-        return URLDeclaration(name: name.lowercased(), url: url)
+		var titleText: Substring? = nil
+		let url = try reader.readCharacters(matching: \.isSameLineNonWhitespace)
+
+		if !reader.didReachEnd,
+			reader.currentCharacter.isSameLineWhitespace {
+			try reader.readWhitespaces()
+			if let delimeter = TitleDelimeter(rawValue: reader.currentCharacter) {
+				reader.advanceIndex()
+				titleText = try reader.read(until: delimeter.closing)
+			}
+		}
+        return URLDeclaration(name: name.lowercased(), url: url, title: titleText)
     }
 }

--- a/Sources/Ink/Internal/URLDeclaration.swift
+++ b/Sources/Ink/Internal/URLDeclaration.swift
@@ -18,9 +18,13 @@ internal struct URLDeclaration: Readable {
         var titleText: Substring? = nil
         let url = try reader.readCharacters(matching: \.isSameLineNonWhitespace)
 
-        if !reader.didReachEnd,
-            reader.currentCharacter.isSameLineWhitespace {
-            try reader.readWhitespaces()
+        if !reader.didReachEnd {
+			if reader.currentCharacter.isNewline {
+				reader.advanceIndex()
+			}
+			if reader.currentCharacter.isSameLineWhitespace {
+				try reader.readWhitespaces()
+			}
             if let delimeter = TitleDelimeter(rawValue: reader.currentCharacter) {
                 reader.advanceIndex()
                 titleText = try reader.read(until: delimeter.closing)

--- a/Sources/Ink/Internal/URLDeclaration.swift
+++ b/Sources/Ink/Internal/URLDeclaration.swift
@@ -7,7 +7,7 @@
 internal struct URLDeclaration: Readable {
     var name: String
     var url: URL
-	var title: Substring?
+    var title: Substring?
 
     static func read(using reader: inout Reader) throws -> Self {
         try reader.read("[")
@@ -15,17 +15,17 @@ internal struct URLDeclaration: Readable {
         try reader.read(":")
         try reader.readWhitespaces()
 
-		var titleText: Substring? = nil
-		let url = try reader.readCharacters(matching: \.isSameLineNonWhitespace)
+        var titleText: Substring? = nil
+        let url = try reader.readCharacters(matching: \.isSameLineNonWhitespace)
 
-		if !reader.didReachEnd,
-			reader.currentCharacter.isSameLineWhitespace {
-			try reader.readWhitespaces()
-			if let delimeter = TitleDelimeter(rawValue: reader.currentCharacter) {
-				reader.advanceIndex()
-				titleText = try reader.read(until: delimeter.closing)
-			}
-		}
+        if !reader.didReachEnd,
+            reader.currentCharacter.isSameLineWhitespace {
+            try reader.readWhitespaces()
+            if let delimeter = TitleDelimeter(rawValue: reader.currentCharacter) {
+                reader.advanceIndex()
+                titleText = try reader.read(until: delimeter.closing)
+            }
+        }
         return URLDeclaration(name: name.lowercased(), url: url, title: titleText)
     }
 }

--- a/Tests/InkTests/ImageTests.swift
+++ b/Tests/InkTests/ImageTests.swift
@@ -27,7 +27,7 @@ final class ImageTests: XCTestCase {
         XCTAssertEqual(html, #"<img src="url" alt="Alt text"/>"#)
     }
 
-	func testImageWithURLAndAltTextAndTitle() {
+    func testImageWithURLAndAltTextAndTitle() {
         let html = MarkdownParser().html(from: "![Alt text](url \"Swift by Sundell\")")
         XCTAssertEqual(html, #"<img src="url" alt="Alt text" title="Swift by Sundell"/>"#)
     }

--- a/Tests/InkTests/ImageTests.swift
+++ b/Tests/InkTests/ImageTests.swift
@@ -27,6 +27,11 @@ final class ImageTests: XCTestCase {
         XCTAssertEqual(html, #"<img src="url" alt="Alt text"/>"#)
     }
 
+	func testImageWithURLAndAltTextAndTitle() {
+        let html = MarkdownParser().html(from: "![Alt text](url \"Swift by Sundell\")")
+        XCTAssertEqual(html, #"<img src="url" alt="Alt text" title="Swift by Sundell"/>"#)
+    }
+
     func testImageWithReferenceAndAltText() {
         let html = MarkdownParser().html(from: """
         ![Alt text][url]

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -13,6 +13,11 @@ final class LinkTests: XCTestCase {
         XCTAssertEqual(html, #"<p><a href="url">Title</a></p>"#)
     }
 
+	func testLinkWithURLAndTitle() {
+        let html = MarkdownParser().html(from: "[Title](url \"Swift by Sundell\")")
+        XCTAssertEqual(html, #"<p><a href="url" title="Swift by Sundell">Title</a></p>"#)
+    }
+
     func testLinkWithReference() {
         let html = MarkdownParser().html(from: """
         [Title][url]
@@ -21,6 +26,36 @@ final class LinkTests: XCTestCase {
         """)
 
         XCTAssertEqual(html, #"<p><a href="swiftbysundell.com">Title</a></p>"#)
+    }
+
+	func testLinkWithReferenceAndDoubleQuoteTitle() {
+        let html = MarkdownParser().html(from: """
+        [Title][url]
+
+        [url]: swiftbysundell.com "Powered by Publish"
+        """)
+
+        XCTAssertEqual(html, #"<p><a href="swiftbysundell.com" title="Powered by Publish">Title</a></p>"#)
+    }
+
+	func testLinkWithReferenceAndSingleQuoteTitle() {
+        let html = MarkdownParser().html(from: """
+        [Title][url]
+
+        [url]: swiftbysundell.com 'Powered by Publish'
+        """)
+
+        XCTAssertEqual(html, #"<p><a href="swiftbysundell.com" title="Powered by Publish">Title</a></p>"#)
+    }
+
+	func testLinkWithReferenceAndParentheticalTitle() {
+        let html = MarkdownParser().html(from: """
+        [Title][url]
+
+        [url]: swiftbysundell.com (Powered by Publish)
+        """)
+
+        XCTAssertEqual(html, #"<p><a href="swiftbysundell.com" title="Powered by Publish">Title</a></p>"#)
     }
 
     func testCaseMismatchedLinkWithReference() {

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -48,6 +48,17 @@ final class LinkTests: XCTestCase {
         XCTAssertEqual(html, #"<p><a href="swiftbysundell.com" title="Powered by Publish">Title</a></p>"#)
     }
 
+	func testLinkWithReferenceAndSingleQuoteTitleOnNextLine() {
+        let html = MarkdownParser().html(from: """
+        [Title][url]
+
+        [url]: swiftbysundell.com
+                      'Powered by Publish'
+        """)
+
+        XCTAssertEqual(html, #"<p><a href="swiftbysundell.com" title="Powered by Publish">Title</a></p>"#)
+    }
+
     func testLinkWithReferenceAndParentheticalTitle() {
         let html = MarkdownParser().html(from: """
         [Title][url]

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -13,7 +13,7 @@ final class LinkTests: XCTestCase {
         XCTAssertEqual(html, #"<p><a href="url">Title</a></p>"#)
     }
 
-	func testLinkWithURLAndTitle() {
+    func testLinkWithURLAndTitle() {
         let html = MarkdownParser().html(from: "[Title](url \"Swift by Sundell\")")
         XCTAssertEqual(html, #"<p><a href="url" title="Swift by Sundell">Title</a></p>"#)
     }
@@ -28,7 +28,7 @@ final class LinkTests: XCTestCase {
         XCTAssertEqual(html, #"<p><a href="swiftbysundell.com">Title</a></p>"#)
     }
 
-	func testLinkWithReferenceAndDoubleQuoteTitle() {
+    func testLinkWithReferenceAndDoubleQuoteTitle() {
         let html = MarkdownParser().html(from: """
         [Title][url]
 
@@ -38,7 +38,7 @@ final class LinkTests: XCTestCase {
         XCTAssertEqual(html, #"<p><a href="swiftbysundell.com" title="Powered by Publish">Title</a></p>"#)
     }
 
-	func testLinkWithReferenceAndSingleQuoteTitle() {
+    func testLinkWithReferenceAndSingleQuoteTitle() {
         let html = MarkdownParser().html(from: """
         [Title][url]
 
@@ -48,7 +48,7 @@ final class LinkTests: XCTestCase {
         XCTAssertEqual(html, #"<p><a href="swiftbysundell.com" title="Powered by Publish">Title</a></p>"#)
     }
 
-	func testLinkWithReferenceAndParentheticalTitle() {
+    func testLinkWithReferenceAndParentheticalTitle() {
         let html = MarkdownParser().html(from: """
         [Title][url]
 


### PR DESCRIPTION
I didn't learn this until yesterday, but apparently [stock Markdown](https://daringfireball.net/projects/markdown/syntax#link "who knew") supports titles in links and images:

```markdown
Here is a [link](https://swiftbysundell.com/ "Good stuff here")
```

Same thing for images, meaning `![Pupper](foo.jpg "A cute puppy")` should turn into:

```html
<img src="foo.jpg" alt="Pupper" title="A cute puppy"/>
```

It's also supported in the link definition syntax, with any amount of same-line whitespace, and two other delimiters:

```markdown
[sbs]: https://swiftbysundell.com     "Now powered by Publish"
[sbs]: https://swiftbysundell.com  'Now powered by Publish'
[sbs]: https://swiftbysundell.com (Now powered by Publish)
```

It even supports putting the title on the next line and using spaces for padding:

```markdown
[sbs]: https://swiftbysundell.com
              "Now powered by Publish"
```

I took a *very* quick pass at implementing this functionality in Ink, and added a few tests to kick the tires. But I probably haven't spent enough time in the Ink codebase to do things 100% idiomatically. So please take or leave any of this!

Thanks @JohnSundell for creating such a powerful Markdown parser—I'm already customizing Ink via a Modifier in a Publish plug-in, which is a testament to how powerful this suite of tools really is!