### PR TITLE
Make images inline elements

### DIFF
--- a/Sources/Ink/API/MarkdownParser.swift
+++ b/Sources/Ink/API/MarkdownParser.swift
@@ -119,7 +119,6 @@ private extension MarkdownParser {
                       nextCharacter: Character?) -> Fragment.Type {
         switch character {
         case "#": return Heading.self
-        case "!": return Image.self
         case "<": return HTML.self
         case ">": return Blockquote.self
         case "`": return CodeBlock.self

--- a/Tests/InkTests/ImageTests.swift
+++ b/Tests/InkTests/ImageTests.swift
@@ -10,30 +10,49 @@ import Ink
 final class ImageTests: XCTestCase {
     func testImageWithURL() {
         let html = MarkdownParser().html(from: "![](url)")
-        XCTAssertEqual(html, #"<img src="url"/>"#)
+        XCTAssertEqual(html, #"<p><img src="url"/></p>"#)
+    }
+
+    func testImagesCreateParagraphs() {
+        let html = MarkdownParser().html(from: "![](url)\n\n![](url)")
+        XCTAssertEqual(html, #"<p><img src="url"/></p><p><img src="url"/></p>"#)
     }
 
     func testImageWithReference() {
         let html = MarkdownParser().html(from: """
         ![][url]
+
         [url]: https://swiftbysundell.com
         """)
 
-        XCTAssertEqual(html, #"<img src="https://swiftbysundell.com"/>"#)
+        XCTAssertEqual(html, #"<p><img src="https://swiftbysundell.com"/></p>"#)
     }
 
     func testImageWithURLAndAltText() {
         let html = MarkdownParser().html(from: "![Alt text](url)")
-        XCTAssertEqual(html, #"<img src="url" alt="Alt text"/>"#)
+        XCTAssertEqual(html, #"<p><img src="url" alt="Alt text"/></p>"#)
     }
 
     func testImageWithReferenceAndAltText() {
         let html = MarkdownParser().html(from: """
         ![Alt text][url]
+
         [url]: swiftbysundell.com
         """)
 
-        XCTAssertEqual(html, #"<img src="swiftbysundell.com" alt="Alt text"/>"#)
+        XCTAssertEqual(html, #"<p><img src="swiftbysundell.com" alt="Alt text"/></p>"#)
+    }
+
+    func testImageWithReferenceAndMoreTextLater() {
+        let html = MarkdownParser().html(from: """
+        ![Alt text][url]
+
+        More text
+
+        [url]: swiftbysundell.com
+        """)
+
+        XCTAssertEqual(html, #"<p><img src="swiftbysundell.com" alt="Alt text"/></p><p>More text</p>"#)
     }
 
     func testImageWithinParagraph() {
@@ -46,9 +65,11 @@ extension ImageTests {
     static var allTests: Linux.TestList<ImageTests> {
         return [
             ("testImageWithURL", testImageWithURL),
+            ("testImagesCreateParagraphs", testImagesCreateParagraphs),
             ("testImageWithReference", testImageWithReference),
             ("testImageWithURLAndAltText", testImageWithURLAndAltText),
             ("testImageWithReferenceAndAltText", testImageWithReferenceAndAltText),
+            ("testImageWithReferenceAndMoreTextLater", testImageWithReferenceAndMoreTextLater),
             ("testImageWithinParagraph", testImageWithinParagraph)
         ]
     }

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -13,6 +13,11 @@ final class LinkTests: XCTestCase {
         XCTAssertEqual(html, #"<p><a href="url">Title</a></p>"#)
     }
 
+    func testLinksCreateParagraphs() {
+        let html = MarkdownParser().html(from: "[Title](url)\n\n[Title](url)")
+        XCTAssertEqual(html, #"<p><a href="url">Title</a></p><p><a href="url">Title</a></p>"#)
+    }
+
     func testLinkWithReference() {
         let html = MarkdownParser().html(from: """
         [Title][url]
@@ -75,6 +80,7 @@ extension LinkTests {
     static var allTests: Linux.TestList<LinkTests> {
         return [
             ("testLinkWithURL", testLinkWithURL),
+            ("testLinksCreateParagraphs", testLinksCreateParagraphs),
             ("testLinkWithReference", testLinkWithReference),
             ("testCaseMismatchedLinkWithReference", testCaseMismatchedLinkWithReference),
             ("testNumericLinkWithReference", testNumericLinkWithReference),

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -13,6 +13,11 @@ final class TextFormattingTests: XCTestCase {
         XCTAssertEqual(html, "<p>Hello, world!</p>")
     }
 
+    func testTwoParagraphs() {
+        let html = MarkdownParser().html(from: "Hello, world!\n\nHello again.")
+        XCTAssertEqual(html, "<p>Hello, world!</p><p>Hello again.</p>")
+    }
+
     func testItalicText() {
         let html = MarkdownParser().html(from: "Hello, *world*!")
         XCTAssertEqual(html, "<p>Hello, <em>world</em>!</p>")
@@ -154,6 +159,7 @@ extension TextFormattingTests {
     static var allTests: Linux.TestList<TextFormattingTests> {
         return [
             ("testParagraph", testParagraph),
+            ("testTwoParagraphs", testTwoParagraphs),
             ("testItalicText", testItalicText),
             ("testBoldText", testBoldText),
             ("testItalicBoldText", testItalicBoldText),


### PR DESCRIPTION
## Summary
tl;dr: This one-line PR allows images to create new paragraphs, by treating them like links, which are also inline elements.

## Overview
This PR addresses an issue with the way that Ink currently handles images. Essentially, when an image is encountered outside of an existing paragraph fragment, Ink treats it as a fragment at the same level as `Heading`, `HTML`, `Blockquote`,  `CodeBlock`, `HorizontalLine` or `Paragraph`.

This prevents a bare image in its own paragraph from being surrounded by `<p></p>`, and probably causes some other undesirable behavior. Images should be treated the same as links, which are very similar and **do** have the expected behavior in Ink.

## Example

Same as a link, an image passed to the parser on its own should result in a surrounding paragraph:

`![](img.jpg)` -> `<p><img src="img.jpg"/></p>`

And the following Markdown should generate two paragraphs:

```markdown
![cat](cat.jpg)

![dog](dog.jpg)
```

⚡️

```html
<p><img src="cat.jpg" alt="cat"/></p>
<p><img src="dog.jpg" alt="dog"/></p>
```

However, currently Ink outputs:
```html
<img src="cat.jpg" alt="cat"/><img src="dog.jpg" alt="dog"/>
```

## Regression / Implications

Drafting this PR uncovered a different bug which I did not address. The unit tests in `ImageTests.swift` put their references on the next line, like so:

```swift
func testImageWithReference() {
    let html = MarkdownParser().html(from: """
    ![][url]
    [url]: https://swiftbysundell.com
    """)

    XCTAssertEqual(html, #"<p><img src="https://swiftbysundell.com"/></p>"#)
}
```

Meanwhile, the `Link` tests all separate the reference by another line:

```swift
func testLinkWithReference() {
    let html = MarkdownParser().html(from: """
    [Title][url]

    [url]: swiftbysundell.com
    """)

    XCTAssertEqual(html, #"<p><a href="swiftbysundell.com">Title</a></p>"#)
}
```

Testing against other Markdown parsers, either style should work. **However,** currently (and also in this PR) in Ink, the reference **must** be separated by more than just a newline. And by making images behave more like links, those `Image` tests stopped working.

So I introduced newlines in the `Image` tests to separate the references, and they are at least at parity with links now.

## Next steps

I made an effort to fix the reference behavior so that the following test would pass, but couldn't immediately see how to resolve it. @JohnSundell  you may be able to work it out a lot faster!

```swift
func testLinkWithReferenceOnNewline() {
    let html = MarkdownParser().html(from: """
    [Title][url]
    [url]: swiftbysundell.com
    """)

    XCTAssertEqual(html, #"<p><a href="swiftbysundell.com">Title</a></p>"#)
}
```

Thanks again John!