### PR TITLE
Add support for Markdown Tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,12 +168,12 @@ Ink supports the following Markdown features:
 - Horizontal lines can be placed using either three asterisks (`***`) or three dashes (`---`) on a new line.
 - HTML can be inlined both at the root level, and within text paragraphs.
 - Blockquotes can be created by placing a greater-than arrow at the start of a line, like this: `> This is a blockquote`.
-- Tables can be created using text formatted with underscores `_` and pipes `|` like so:
+- Tables can be created using text formatted with underscores `_` (if you want headers) and pipes `|` like so:
 ```
-| Header                        | Header 2    |
-| ------------------------------ | ----------- |
-| Row 1                   | Column      | Column       |
-| Row 2                     | Column       | Column        |
+| Header | Header 2 |
+| ------ | -------- |
+| Row 1  | Cell 1   |
+| Row 2  | Cell 2   |
 ```
 
 Please note that, being a very young implementation, Ink does not fully support all Markdown specs, such as [CommonMark](https://commonmark.org). Ink definitely aims to cover as much ground as possible, and to include support for the most commonly used Markdown features, but if complete CommonMark compatibility is what you’re looking for — then you might want to check out tools like [CMark](https://github.com/commonmark/cmark).

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Ink supports the following Markdown features:
 - Horizontal lines can be placed using either three asterisks (`***`) or three dashes (`---`) on a new line.
 - HTML can be inlined both at the root level, and within text paragraphs.
 - Blockquotes can be created by placing a greater-than arrow at the start of a line, like this: `> This is a blockquote`.
-- Tables can be created using text formatted with underscores `_` (if you want headers) and pipes `|` like so:
+- Tables can be created using the following syntax (the line consisting of dashes (`-`) can be omitted to create a table without a header row):
 ```
 | Header | Header 2 |
 | ------ | -------- |

--- a/README.md
+++ b/README.md
@@ -168,6 +168,13 @@ Ink supports the following Markdown features:
 - Horizontal lines can be placed using either three asterisks (`***`) or three dashes (`---`) on a new line.
 - HTML can be inlined both at the root level, and within text paragraphs.
 - Blockquotes can be created by placing a greater-than arrow at the start of a line, like this: `> This is a blockquote`.
+- Tables can be created using text formatted with underscores `_` and pipes `|` like so:
+```
+| Header                        | Header 2    |
+| ------------------------------ | ----------- |
+| Row 1                   | Column      | Column       |
+| Row 2                     | Column       | Column        |
+```
 
 Please note that, being a very young implementation, Ink does not fully support all Markdown specs, such as [CommonMark](https://commonmark.org). Ink definitely aims to cover as much ground as possible, and to include support for the most commonly used Markdown features, but if complete CommonMark compatibility is what you’re looking for — then you might want to check out tools like [CMark](https://github.com/commonmark/cmark).
 

--- a/Sources/Ink/API/MarkdownParser.swift
+++ b/Sources/Ink/API/MarkdownParser.swift
@@ -53,7 +53,7 @@ public struct MarkdownParser {
             do {
                 if metadata == nil, fragments.isEmpty, reader.currentCharacter == "-" {
                     if let parsedMetadata = try? Metadata.readOrRewind(using: &reader) {
-                        metadata = parsedMetadata
+                        metadata = parsedMetadata.applyingModifiers(modifiers)
                         continue
                     }
                 }

--- a/Sources/Ink/API/MarkdownParser.swift
+++ b/Sources/Ink/API/MarkdownParser.swift
@@ -127,6 +127,7 @@ private extension MarkdownParser {
              "*" where character == nextCharacter:
             return HorizontalLine.self
         case "-", "*", "+", \.isNumber: return List.self
+        case "|": return Table.self
         default: return Paragraph.self
         }
     }

--- a/Sources/Ink/API/Modifier.swift
+++ b/Sources/Ink/API/Modifier.swift
@@ -16,7 +16,8 @@
 public struct Modifier {
     /// The type of input that each modifier is given, which both
     /// contains the HTML that was generated for a fragment, and
-    /// its raw Markdown representation.
+    /// its raw Markdown representation. Note that for metadata
+    /// targets, the two input arguments will be equivalent.
     public typealias Input = (html: String, markdown: Substring)
     /// The type of closure that Modifiers are based on. Each
     /// modifier is given a set of input, and is expected to return
@@ -39,6 +40,8 @@ public struct Modifier {
 
 public extension Modifier {
     enum Target {
+        case metadataKeys
+        case metadataValues
         case blockquotes
         case codeBlocks
         case headings

--- a/Sources/Ink/API/Modifier.swift
+++ b/Sources/Ink/API/Modifier.swift
@@ -52,5 +52,6 @@ public extension Modifier {
         case links
         case lists
         case paragraphs
+        case tables
     }
 }

--- a/Sources/Ink/API/Modifier.swift
+++ b/Sources/Ink/API/Modifier.swift
@@ -51,7 +51,7 @@ public extension Modifier {
         case inlineCode
         case links
         case lists
-        case paragraphs
         case tables
+        case paragraphs
     }
 }

--- a/Sources/Ink/Internal/Metadata.swift
+++ b/Sources/Ink/Internal/Metadata.swift
@@ -42,6 +42,26 @@ internal struct Metadata: Readable {
 
         throw Reader.Error()
     }
+
+    func applyingModifiers(_ modifiers: ModifierCollection) -> Self {
+        var modified = self
+
+        modifiers.applyModifiers(for: .metadataKeys) { modifier in
+            for (key, value) in modified.values {
+                let newKey = modifier.closure((key, Substring(key)))
+                modified.values[key] = nil
+                modified.values[newKey] = value
+            }
+        }
+
+        modifiers.applyModifiers(for: .metadataValues) { modifier in
+            modified.values = modified.values.mapValues { value in
+                modifier.closure((value, Substring(value)))
+            }
+        }
+
+        return modified
+    }
 }
 
 private extension Metadata {

--- a/Sources/Ink/Internal/Table.swift
+++ b/Sources/Ink/Internal/Table.swift
@@ -1,0 +1,69 @@
+/**
+ *  Ink
+ *  Copyright (c) John Sundell 2020
+ *  MIT license, see LICENSE file for details
+ */
+
+import Foundation
+
+struct Table: Fragment {
+    var modifierTarget: Modifier.Target { .tables }
+
+    private var code: String
+
+    static func read(using reader: inout Reader) throws -> Table {
+        try reader.read("|")
+        reader.rewindIndex()
+
+        var code = ""
+
+        outerWhile: while !reader.didReachEnd {
+            switch reader.currentCharacter {
+            case \.isNewline:
+                code += "</tr>"
+                reader.advanceIndex(by: 2)
+                break
+            case "|":
+                let line = reader.readUntilEndOfLine()
+
+                guard line.split(separator: "|").count >= 2 else { throw Reader.Error() }
+
+                // If line only contains header-dashes, change first row from <td> to <th>
+                if String(line)
+                    .replacingOccurrences(of: " ", with: "")
+                    .replacingOccurrences(of: "|", with: "")
+                    .replacingOccurrences(of: "-", with: "")
+                    .isEmpty {
+                    code = code
+                             .replacingOccurrences(of: "<td>", with: "<th>")
+                             .replacingOccurrences(of: "</td>", with: "</th>")
+                    break
+                }
+
+                let columns = line.split(separator: "|")
+                code += "<tr>"
+                columns.forEach { cell in
+                    let trimmedCell = cell.trimmingLeadingWhitespaces().trimmingTrailingWhitespaces()
+                    code += "<td>\(trimmedCell)</td>"
+                }
+
+                code += "</tr>"
+            default:
+                throw Reader.Error()
+            }
+        }
+
+        guard !code.isEmpty else { throw Reader.Error() }
+        code = "<table>\(code)</table>"
+
+        return Table(code: code)
+    }
+
+    func html(usingURLs urls: NamedURLCollection, modifiers: ModifierCollection) -> String {
+        code
+    }
+
+    func plainText() -> String {
+        code
+    }
+}

--- a/Sources/Ink/Internal/Table.swift
+++ b/Sources/Ink/Internal/Table.swift
@@ -9,192 +9,86 @@ import Foundation
 struct Table: Fragment {
     var modifierTarget: Modifier.Target { .tables }
 
-    private var header: [FormattedText]
-    private var body: [[FormattedText]]
-    private var alignments: [Alignment]
+    private var header: Row?
+    private var rows = [Row]()
+    private var columnCount = 0
+    private var columnAlignments = [ColumnAlignment]()
 
     static func read(using reader: inout Reader) throws -> Table {
-        var header: [FormattedText] = []
-        var body: [[FormattedText]] = [[]]
-        var alignments: [Alignment] = []
+        var table = Table()
 
-        while !reader.didReachEnd {
-            guard reader.currentCharacter == "|" else { break }
-
-            // Advance reader from here to here
-            // +-------------------+       +
-            // |                           |
-            // v v-------------------------+
-            // | table | cells |
-            reader.advanceIndex()
-            reader.discardWhitespaces()
-
-            // Read FormattedText from here to here (trailing spaces are removed automatically)
-            //   +---------------------+       +
-            //   |                             |
-            //   v     v-----------------------+
-            // | table | cells |
-            let text: FormattedText = .read(using: &reader, terminators: ["|", "\n"])
-            guard !reader.didReachEnd else { break }
-
-            // If the reader is at "|", we should continue parsing this line
-            if reader.currentCharacter == "|" {
-                body[body.count - 1].append(text)
-            // If the reader is at "\n", we should move to the next line
-            } else {
-                body.append([])
-                reader.advanceIndex()
-            }
-        }
-
-        // We can be here by being at end of file, or on a new row
-        // If we are at the end of file, the previous character should have been "|"
-        // If we are on a new row, the last character should have been a "\n"
-        if reader.previousCharacter != "|", reader.previousCharacter != "\n" {
-            throw Reader.Error()
-        }
-
-        let columnCount = body[0].count
-
-        // If we are done parsing the table, remove the empty array we appended
-        if body.last?.isEmpty == true {
-            body.removeLast()
-        }
-
-        if body.count > 1 {
-            // If the second line's cells only contain "-" and ":", we have a header
-            let hasHeader = body[1].allSatisfy { formattedText in
-                formattedText.plainText().filter { !["-", ":"].contains($0) }.isEmpty
+        while !reader.didReachEnd, !reader.currentCharacter.isNewline {
+            guard reader.currentCharacter == "|" else {
+                break
             }
 
-            if hasHeader {
-                // The header row and delimiter row must have the same number of cells
-                guard body[0].count == body[1].count else {
-                    throw Reader.Error()
-                }
-
-                // Create alignments based on leading and trailing ":"
-                alignments = body[1].map {
-                    let cell = $0.plainText()
-                    switch (cell.first, cell.last) {
-                    case (":", ":"):
-                        return .center
-                    case (":", _):
-                        return .left
-                    case (_, ":"):
-                        return .right
-                    default:
-                        return .none
-                    }
-                }
-
-                // Move the header row from body to header, and remove the delimiter row
-                header = body.removeFirst()
-                body.removeFirst()
-            }
+            let row = try reader.readTableRow()
+            table.rows.append(row)
+            table.columnCount = max(table.columnCount, row.count)
         }
 
-        for rowIndex in body.indices {
-            switch body[rowIndex].count {
-            // If row has fewer columns than it should, pad with empty cells
-            case let num where num < columnCount:
-                body[rowIndex].append(contentsOf: Array(repeating: FormattedText(), count: columnCount - num))
-            // If row has more columns than it should, discard the extras
-            case let num where num > columnCount:
-                body[rowIndex].removeLast(num - columnCount)
-            default:
-                continue
-            }
-        }
-
-        // Fill alignment array if there is no header
-        if header.isEmpty {
-            alignments = Array(repeating: .none, count: columnCount)
-        }
-
-        return Table(header: header, body: body, alignments: alignments)
+        guard !table.rows.isEmpty else { throw Reader.Error() }
+        table.formHeaderAndColumnAlignmentsIfNeeded()
+        return table
     }
 
-    func html(usingURLs urls: NamedURLCollection, modifiers: ModifierCollection) -> String {
-        var tableString = ""
+    func html(usingURLs urls: NamedURLCollection,
+              modifiers: ModifierCollection) -> String {
+        var html = ""
+        let render: () -> String = { "<table>\(html)</table>" }
 
-        let headerString = zip(header, alignments).reduce("") { (headerString, cell) in
-            let (cell, alignment) = cell
-            return headerString
-                + "<th\(alignment.attribute)>\(cell.html(usingURLs: urls, modifiers: modifiers))</th>"
+        if let header = header {
+            let rowHTML = self.html(
+                forRow: header,
+                cellElementName: "th",
+                urls: urls,
+                modifiers: modifiers
+            )
+
+            html.append("<thead>\(rowHTML)</thead>")
         }
 
-        if !headerString.isEmpty {
-            tableString += "<thead><tr>\(headerString)</tr></thead>"
+        guard !rows.isEmpty else {
+            return render()
         }
 
-        let rowStrings = body.map { row in
-            zip(row, alignments).reduce("") { (rowString, cell) in
-                let (cell, alignment) = cell
-                return rowString
-                    + "<td\(alignment.attribute)>\(cell.html(usingURLs: urls, modifiers: modifiers))</td>"
-            }
+        html.append("<tbody>")
+
+        for row in rows {
+            let rowHTML = self.html(
+                forRow: row,
+                cellElementName: "td",
+                urls: urls,
+                modifiers: modifiers
+            )
+
+            html.append(rowHTML)
         }
 
-        if !rowStrings.isEmpty {
-            let bodyString = rowStrings.reduce("") { (bodyString, rowString) in
-                bodyString + "<tr>\(rowString)</tr>"
-            }
-
-            tableString += "<tbody>\(bodyString)</tbody>"
-        }
-
-        return "<table>\(tableString)</table>"
+        html.append("</tbody>")
+        return render()
     }
 
     func plainText() -> String {
-        let columnCount = alignments.count
-        var columnWidths = Array(repeating: 0, count: columnCount)
+        var text = header.map(plainText) ?? ""
 
-        if !header.isEmpty {
-            columnWidths = header.map {
-                $0.plainText().count
-            }
+        for row in rows {
+            if !text.isEmpty { text.append("\n") }
+            text.append(plainText(forRow: row))
         }
 
-        if !body.isEmpty {
-            for row in body {
-                columnWidths = zip(columnWidths, row).map {
-                    let (width, cell) = $0
-                    return max(width, cell.plainText().count)
-                }
-            }
-        }
-
-        var plainText = ""
-
-        let header = zip(self.header, columnWidths).map { (title, width) in
-            title.plainText().padding(toLength: width, withPad: " ", startingAt: 0)
-        }
-        let divider = columnWidths.map { String(repeating: "-", count: $0) }
-        let body = self.body.map { row in
-            zip(row, columnWidths).map { (cell, width) in
-                cell.plainText().padding(toLength: width, withPad: " ", startingAt: 0)
-            }
-        }
-
-        if !header.isEmpty {
-            plainText += "| \(header.joined(separator: " | ")) |\n"
-            plainText += "| \(divider.joined(separator: " | ")) |\n"
-        }
-
-        if !body.isEmpty {
-            body.forEach { row in
-                plainText += "| \(row.joined(separator: " | ")) |\n"
-            }
-        }
-
-        return plainText
+        return text
     }
 }
 
 private extension Table {
-    enum Alignment {
+    typealias Row = [FormattedText]
+    typealias Cell = FormattedText
+
+    static let delimiters: Set<Character> = ["|", "\n"]
+    static let allowedHeaderCharacters: Set<Character> = ["-", ":"]
+
+    enum ColumnAlignment {
         case none
         case left
         case center
@@ -212,5 +106,114 @@ private extension Table {
                 return #" align="right""#
             }
         }
+    }
+
+    mutating func formHeaderAndColumnAlignmentsIfNeeded() {
+        guard rows.count > 1 else { return }
+        guard rows[0].count == rows[1].count else { return }
+
+        let textPredicate = Self.allowedHeaderCharacters.contains
+        var alignments = [ColumnAlignment]()
+
+        for cell in rows[1] {
+            let text = cell.plainText()
+
+            guard text.allSatisfy(textPredicate) else {
+                return
+            }
+
+            alignments.append(parseColumnAlignment(from: text))
+        }
+
+        header = rows[0]
+        columnAlignments = alignments
+        rows.removeSubrange(0...1)
+    }
+
+    func parseColumnAlignment(from text: String) -> ColumnAlignment {
+        switch (text.first, text.last) {
+        case (":", ":"):
+            return .center
+        case (":", _):
+            return .left
+        case (_, ":"):
+            return .right
+        default:
+            return .none
+        }
+    }
+
+    func html(forRow row: Row,
+              cellElementName: String,
+              urls: NamedURLCollection,
+              modifiers: ModifierCollection) -> String {
+        var html = "<tr>"
+
+        for index in 0..<columnCount {
+            let cell = index < row.count ? row[index] : nil
+            let contents = cell?.html(usingURLs: urls, modifiers: modifiers)
+
+            html.append(htmlForCell(
+                at: index,
+                contents: contents ?? "",
+                elementName: cellElementName
+            ))
+        }
+
+        return html + "</tr>"
+    }
+
+    func htmlForCell(at index: Int, contents: String, elementName: String) -> String {
+        let alignment = index < columnAlignments.count
+            ? columnAlignments[index]
+            : .none
+
+        let tags = (
+            opening: "<\(elementName)\(alignment.attribute)>",
+            closing: "</\(elementName)>"
+        )
+
+        return tags.opening + contents + tags.closing
+    }
+
+    func plainText(forRow row: Row) -> String {
+        var text = ""
+
+        for index in 0..<columnCount {
+            let cell = index < row.count ? row[index] : nil
+            if index > 0 { text.append(" | ") }
+            text.append(cell?.plainText() ?? "")
+        }
+
+        return text + " |"
+    }
+}
+
+private extension Reader {
+    mutating func readTableRow() throws -> Table.Row {
+        try readTableDelimiter()
+        var row = Table.Row()
+
+        while !didReachEnd {
+            let cell = FormattedText.read(
+                using: &self,
+                terminators: Table.delimiters
+            )
+
+            try readTableDelimiter()
+            row.append(cell)
+
+            if !didReachEnd, currentCharacter.isNewline {
+                advanceIndex()
+                break
+            }
+        }
+
+        return row
+    }
+
+    mutating func readTableDelimiter() throws {
+        try read("|")
+        discardWhitespaces()
     }
 }

--- a/Tests/InkTests/MarkdownTests.swift
+++ b/Tests/InkTests/MarkdownTests.swift
@@ -67,6 +67,29 @@ final class MarkdownTests: XCTestCase {
         XCTAssertEqual(markdown.html, "<h1>Title</h1>")
     }
 
+    func testMetadataModifiers() {
+        let parser = MarkdownParser(modifiers: [
+            Modifier(target: .metadataKeys) { key, _ in
+                "ModifiedKey-" + key
+            },
+            Modifier(target: .metadataValues) { value, _ in
+                "ModifiedValue-" + value
+            }
+        ])
+
+        let markdown = parser.parse("""
+        ---
+        keyA: valueA
+        keyB: valueB
+        ---
+        """)
+
+        XCTAssertEqual(markdown.metadata, [
+            "ModifiedKey-keyA" : "ModifiedValue-valueA",
+            "ModifiedKey-keyB" : "ModifiedValue-valueB"
+        ])
+    }
+
     func testPlainTextTitle() {
         let markdown = MarkdownParser().parse("""
         # Hello, world!
@@ -115,6 +138,7 @@ extension MarkdownTests {
             ("testDiscardingEmptyMetadataValues", testDiscardingEmptyMetadataValues),
             ("testMergingOrphanMetadataValueIntoPreviousOne", testMergingOrphanMetadataValueIntoPreviousOne),
             ("testMissingMetadata", testMissingMetadata),
+            ("testMetadataModifiers", testMetadataModifiers),
             ("testPlainTextTitle", testPlainTextTitle),
             ("testRemovingTrailingMarkersFromTitle", testRemovingTrailingMarkersFromTitle),
             ("testConvertingFormattedTitleTextToPlainText", testConvertingFormattedTitleTextToPlainText),

--- a/Tests/InkTests/TableTests.swift
+++ b/Tests/InkTests/TableTests.swift
@@ -29,6 +29,19 @@ final class TableTests: XCTestCase {
         XCTAssertEqual(html, #"<table><tr><th>Language</th><th>Creator</th><th>Year</th></tr><tr><td>Swift</td><td>Apple</td><td>2014</td></tr><tr><td>Objective-C</td><td>Tom Love and Brad Cox</td><td>1984</td></tr></table>"#)
     }
 
+    func testTableSurroundedByText() {
+        let html = MarkdownParser().html(from: """
+        This is a paragraph
+
+        | Swift       | Apple                 |
+        | Objective-C | Tom Love and Brad Cox |
+
+        Another paragraph
+        """)
+
+        XCTAssertEqual(html, #"<p>This is a paragraph</p><table><tr><td>Swift</td><td>Apple</td></tr><tr><td>Objective-C</td><td>Tom Love and Brad Cox</td></tr></table><p>Another paragraph</p>"#)
+    }
+
     func testTableWithUnalignedColumns() {
         let html = MarkdownParser().html(from: """
         | Language                        | Creator    | Year |
@@ -64,6 +77,7 @@ extension TableTests {
         return [
             ("testTableWithoutHeader", testTableWithoutHeader),
             ("testTableWithHeader", testTableWithHeader),
+            ("testTableSurroundedByText", testTableSurroundedByText),
             ("testTableWithUnalignedColumns", testTableWithUnalignedColumns),
             ("testIncompleteTable", testIncompleteTable),
             ("testInvalidTable", testInvalidTable)

--- a/Tests/InkTests/TableTests.swift
+++ b/Tests/InkTests/TableTests.swift
@@ -1,0 +1,72 @@
+/**
+ *  Ink
+ *  Copyright (c) John Sundell 2020
+ *  MIT license, see LICENSE file for details
+ */
+
+import XCTest
+import Ink
+
+final class TableTests: XCTestCase {
+
+    func testTableWithoutHeader() {
+        let html = MarkdownParser().html(from: """
+        | Swift       | Apple                 |
+        | Objective-C | Tom Love and Brad Cox |
+        """)
+
+        XCTAssertEqual(html, #"<table><tr><td>Swift</td><td>Apple</td></tr><tr><td>Objective-C</td><td>Tom Love and Brad Cox</td></tr></table>"#)
+    }
+
+    func testTableWithHeader() {
+        let html = MarkdownParser().html(from: """
+        | Language     | Creator               | Year |
+        | ------------ | --------------------- | ---- |
+        | Swift        | Apple                 | 2014 |
+        | Objective-C  | Tom Love and Brad Cox | 1984 |
+        """)
+
+        XCTAssertEqual(html, #"<table><tr><th>Language</th><th>Creator</th><th>Year</th></tr><tr><td>Swift</td><td>Apple</td><td>2014</td></tr><tr><td>Objective-C</td><td>Tom Love and Brad Cox</td><td>1984</td></tr></table>"#)
+    }
+
+    func testTableWithUnalignedColumns() {
+        let html = MarkdownParser().html(from: """
+        | Language                        | Creator    | Year |
+        | ------------------------------ | ----------- | ------------ |
+        | Swift                    | Apple      | 2014       |
+        | Objective-C                     | Tom Love and Brad Cox       | 1984        |
+        """)
+
+        XCTAssertEqual(html, #"<table><tr><th>Language</th><th>Creator</th><th>Year</th></tr><tr><td>Swift</td><td>Apple</td><td>2014</td></tr><tr><td>Objective-C</td><td>Tom Love and Brad Cox</td><td>1984</td></tr></table>"#)
+    }
+
+    func testIncompleteTable() {
+        let html = MarkdownParser().html(from: """
+        | one | two |
+        | three |
+        | four | five | six
+        """)
+
+        XCTAssertEqual(html, "<p>| one | two | | three | | four | five | six</p>")
+    }
+
+    func testInvalidTable() {
+        let html = MarkdownParser().html(from: """
+        |123 Not a table
+        """)
+
+        XCTAssertEqual(html, "<p>|123 Not a table</p>")
+    }
+}
+
+extension TableTests {
+    static var allTests: Linux.TestList<TableTests> {
+        return [
+            ("testTableWithoutHeader", testTableWithoutHeader),
+            ("testTableWithHeader", testTableWithHeader),
+            ("testTableWithUnalignedColumns", testTableWithUnalignedColumns),
+            ("testIncompleteTable", testIncompleteTable),
+            ("testInvalidTable", testInvalidTable)
+        ]
+    }
+}

--- a/Tests/InkTests/TableTests.swift
+++ b/Tests/InkTests/TableTests.swift
@@ -8,45 +8,69 @@ import XCTest
 import Ink
 
 final class TableTests: XCTestCase {
-
     func testTableWithoutHeader() {
         let html = MarkdownParser().html(from: """
-        | Swift       | Apple                 |
-        | Objective-C | Tom Love and Brad Cox |
+        | HeaderA | HeaderB |
+        | CellA   | CellB   |
         """)
 
-        XCTAssertEqual(html, #"<table><tbody><tr><td>Swift</td><td>Apple</td></tr><tr><td>Objective-C</td><td>Tom Love and Brad Cox</td></tr></tbody></table>"#)
+        XCTAssertEqual(html, """
+        <table><tbody>\
+        <tr><td>HeaderA</td><td>HeaderB</td></tr>\
+        <tr><td>CellA</td><td>CellB</td></tr>\
+        </tbody></table>
+        """)
     }
 
     func testTableWithHeader() {
         let html = MarkdownParser().html(from: """
-        | Language     | Creator               | Year |
-        | ------------ | --------------------- | ---- |
-        | Swift        | Apple                 | 2014 |
-        | Objective-C  | Tom Love and Brad Cox | 1984 |
+        | HeaderA | HeaderB | HeaderC |
+        | ------- | ------- | ------- |
+        | CellA1  | CellB1  | CellC1  |
+        | CellA2  | CellB2  | CellC2  |
         """)
 
-        XCTAssertEqual(html, #"<table><thead><tr><th>Language</th><th>Creator</th><th>Year</th></tr></thead><tbody><tr><td>Swift</td><td>Apple</td><td>2014</td></tr><tr><td>Objective-C</td><td>Tom Love and Brad Cox</td><td>1984</td></tr></tbody></table>"#)
+        XCTAssertEqual(html, """
+        <table>\
+        <thead><tr><th>HeaderA</th><th>HeaderB</th><th>HeaderC</th></tr></thead>\
+        <tbody>\
+        <tr><td>CellA1</td><td>CellB1</td><td>CellC1</td></tr>\
+        <tr><td>CellA2</td><td>CellB2</td><td>CellC2</td></tr>\
+        </tbody>\
+        </table>
+        """)
     }
 
     func testTableWithUnalignedColumns() {
         let html = MarkdownParser().html(from: """
-        | Language                        | Creator    | Year |
+        | HeaderA                        | HeaderB    | HeaderC |
         | ------------------------------ | ----------- | ------------ |
-        | Swift                    | Apple      | 2014       |
-        | Objective-C                     | Tom Love and Brad Cox       | 1984        |
+        | CellA1                    | CellB1      | CellC1       |
+        | CellA2                   | CellB2       | CellC2        |
         """)
 
-        XCTAssertEqual(html, #"<table><thead><tr><th>Language</th><th>Creator</th><th>Year</th></tr></thead><tbody><tr><td>Swift</td><td>Apple</td><td>2014</td></tr><tr><td>Objective-C</td><td>Tom Love and Brad Cox</td><td>1984</td></tr></tbody></table>"#)
+        XCTAssertEqual(html, """
+        <table>\
+        <thead><tr><th>HeaderA</th><th>HeaderB</th><th>HeaderC</th></tr></thead>\
+        <tbody>\
+        <tr><td>CellA1</td><td>CellB1</td><td>CellC1</td></tr>\
+        <tr><td>CellA2</td><td>CellB2</td><td>CellC2</td></tr>\
+        </tbody>\
+        </table>
+        """)
     }
 
     func testTableWithOnlyHeader() {
         let html = MarkdownParser().html(from: """
-        | Language     | Creator               | Year |
-        | ------------ | --------------------- | ---- |
+        | HeaderA   | HeaderB   | HeaderC |
+        | ----------| ----------| ------- |
         """)
 
-        XCTAssertEqual(html, #"<table><thead><tr><th>Language</th><th>Creator</th><th>Year</th></tr></thead></table>"#)
+        XCTAssertEqual(html, """
+        <table>\
+        <thead><tr><th>HeaderA</th><th>HeaderB</th><th>HeaderC</th></tr></thead>\
+        </table>
+        """)
     }
 
     func testIncompleteTable() {
@@ -71,13 +95,19 @@ final class TableTests: XCTestCase {
         let html = MarkdownParser().html(from: """
         A paragraph.
 
-        | Swift       | Apple                 |
-        | Objective-C | Tom Love and Brad Cox |
+        | A | B |
+        | C | D |
 
         Another paragraph.
         """)
 
-        XCTAssertEqual(html, "<p>A paragraph.</p><table><tbody><tr><td>Swift</td><td>Apple</td></tr><tr><td>Objective-C</td><td>Tom Love and Brad Cox</td></tr></tbody></table><p>Another paragraph.</p>")
+        XCTAssertEqual(html, """
+        <p>A paragraph.</p>\
+        <table><tbody>\
+        <tr><td>A</td><td>B</td></tr><tr><td>C</td><td>D</td></tr>\
+        </tbody></table>\
+        <p>Another paragraph.</p>
+        """)
     }
 
     func testTableWithUnevenColumns() {
@@ -89,7 +119,16 @@ final class TableTests: XCTestCase {
         | three |
         """)
 
-        XCTAssertEqual(html, "<table><tbody><tr><td>one</td><td>two</td></tr><tr><td>three</td><td>four</td></tr></tbody></table><table><tbody><tr><td>one</td><td>two</td></tr><tr><td>three</td><td></td></tr></tbody></table>")
+        XCTAssertEqual(html, """
+        <table><tbody>\
+        <tr><td>one</td><td>two</td><td></td></tr>\
+        <tr><td>three</td><td>four</td><td>five</td></tr>\
+        </tbody></table>\
+        <table><tbody>\
+        <tr><td>one</td><td>two</td></tr>\
+        <tr><td>three</td><td></td></tr>\
+        </tbody></table>
+        """)
     }
 
     func testTableWithInternalMarkdown() {
@@ -100,7 +139,17 @@ final class TableTests: XCTestCase {
         | `code` | in         | table        |
         """)
 
-        XCTAssertEqual(html, #"<table><thead><tr><th>Table</th><th>Header</th><th><a href="/uri">Link</a></th></tr></thead><tbody><tr><td>Some</td><td><em>emphasis</em></td><td>and</td></tr><tr><td><code>code</code></td><td>in</td><td>table</td></tr></tbody></table>"#)
+        XCTAssertEqual(html, """
+        <table>\
+        <thead>\
+        <tr><th>Table</th><th>Header</th><th><a href="/uri">Link</a></th></tr>\
+        </thead>\
+        <tbody>\
+        <tr><td>Some</td><td><em>emphasis</em></td><td>and</td></tr>\
+        <tr><td><code>code</code></td><td>in</td><td>table</td></tr>\
+        </tbody>\
+        </table>
+        """)
     }
 
     func testTableWithAlignment() {
@@ -110,28 +159,49 @@ final class TableTests: XCTestCase {
         | One | Two | Three |
         """)
 
-        XCTAssertEqual("\n"+html, #"\#n<table><thead><tr><th align="left">Left</th><th align="center">Center</th><th align="right">Right</th></tr></thead><tbody><tr><td align="left">One</td><td align="center">Two</td><td align="right">Three</td></tr></tbody></table>"#)
+        XCTAssertEqual(html, """
+        <table>\
+        <thead><tr>\
+        <th align="left">Left</th><th align="center">Center</th><th align="right">Right</th>\
+        </tr></thead>\
+        <tbody>\
+        <tr><td align="left">One</td><td align="center">Two</td><td align="right">Three</td></tr>\
+        </tbody>\
+        </table>
+        """)
     }
 
     func testMissingPipeEndsTable() {
         let html = MarkdownParser().html(from: """
-        | abc | def |
-        | --- | --- |
-        | bar | baz |
-        > bar
+        | HeaderA | HeaderB |
+        | ------- | ------- |
+        | CellA   | CellB   |
+        > Quote
         """)
 
-        XCTAssertEqual(html, "<table><thead><tr><th>abc</th><th>def</th></tr></thead><tbody><tr><td>bar</td><td>baz</td></tr></tbody></table><blockquote><p>bar</p></blockquote>")
+        XCTAssertEqual(html, """
+        <table>\
+        <thead><tr><th>HeaderA</th><th>HeaderB</th></tr></thead>\
+        <tbody><tr><td>CellA</td><td>CellB</td></tr></tbody>\
+        </table>\
+        <blockquote><p>Quote</p></blockquote>
+        """)
     }
 
-    func testHeaderAndDelimiterRowsMatchCount() {
+    func testHeaderNotParsedForColumnCountMismatch() {
         let html = MarkdownParser().html(from: """
-        | abc | def |
-        | --- |
-        | bar |
+        | HeaderA | HeaderB |
+        | ------- |
+        | CellA   | CellB |
         """)
 
-        XCTAssertEqual(html, "<p>| abc | def | | --- | | bar |</p>")
+        XCTAssertEqual(html, """
+        <table><tbody>\
+        <tr><td>HeaderA</td><td>HeaderB</td></tr>\
+        <tr><td>-------</td><td></td></tr>\
+        <tr><td>CellA</td><td>CellB</td></tr>\
+        </tbody></table>
+        """)
     }
 }
 
@@ -149,7 +219,7 @@ extension TableTests {
             ("testTableWithInternalMarkdown", testTableWithInternalMarkdown),
             ("testTableWithAlignment", testTableWithAlignment),
             ("testMissingPipeEndsTable", testMissingPipeEndsTable),
-            ("testHeaderAndDelimiterRowsMatchCount", testHeaderAndDelimiterRowsMatchCount),
+            ("testHeaderNotParsedForColumnCountMismatch", testHeaderNotParsedForColumnCountMismatch),
         ]
     }
 }

--- a/Tests/InkTests/XCTestManifests.swift
+++ b/Tests/InkTests/XCTestManifests.swift
@@ -17,6 +17,7 @@ public func allTests() -> [Linux.TestCase] {
         Linux.makeTestCase(using: ListTests.allTests),
         Linux.makeTestCase(using: MarkdownTests.allTests),
         Linux.makeTestCase(using: ModifierTests.allTests),
-        Linux.makeTestCase(using: TextFormattingTests.allTests)
+        Linux.makeTestCase(using: TextFormattingTests.allTests),
+        Linux.makeTestCase(using: TableTests.allTests)
     ]
 }


### PR DESCRIPTION
After lots of trial and error (getting to know how the reader works), I have finally succeeded in making a basic implementation for Markdown Tables.

This does at this stage not support all formats out there. It support the general table format which is the one I personally use.

Tables can be with or without headers.

Improvements and suggestions are most welcome!