### PR TITLE
Allow Modifiers for plain text

### DIFF
--- a/Sources/Ink/API/Modifier.swift
+++ b/Sources/Ink/API/Modifier.swift
@@ -52,5 +52,6 @@ public extension Modifier {
         case links
         case lists
         case paragraphs
+		case text
     }
 }

--- a/Sources/Ink/API/Modifier.swift
+++ b/Sources/Ink/API/Modifier.swift
@@ -52,6 +52,6 @@ public extension Modifier {
         case links
         case lists
         case paragraphs
-		case text
+        case text
     }
 }

--- a/Sources/Ink/Internal/FormattedText.swift
+++ b/Sources/Ink/Internal/FormattedText.swift
@@ -32,7 +32,12 @@ internal struct FormattedText: Readable, HTMLConvertible, PlainTextConvertible {
             case .linebreak:
                 string.append("<br>")
             case .text(let text):
-                string.append(String(text))
+                let html = text.html(
+                    usingURLs: urls,
+                    rawString: text,
+                    applyingModifiers: modifiers
+                )
+                string.append(html)
             case .styleMarker(let marker):
                 let html = marker.html(usingURLs: urls, modifiers: modifiers)
                 string.append(html)

--- a/Sources/Ink/Internal/Substring+Modifiable.swift
+++ b/Sources/Ink/Internal/Substring+Modifiable.swift
@@ -1,0 +1,22 @@
+//
+//  Substring+Modifiable.swift
+//  
+//
+//  Created by Ben Syverson on 2020/01/29.
+//
+
+extension Substring: HTMLConvertible {
+    func html(usingURLs urls: NamedURLCollection, modifiers: ModifierCollection) -> String {
+        return String(self)
+    }
+}
+
+extension Substring: PlainTextConvertible {
+    func plainText() -> String {
+        return String(self)
+    }
+}
+
+extension Substring: Modifiable {
+    var modifierTarget: Modifier.Target { .text }
+}

--- a/Tests/InkTests/ModifierTests.swift
+++ b/Tests/InkTests/ModifierTests.swift
@@ -76,6 +76,42 @@ final class ModifierTests: XCTestCase {
 
         XCTAssertEqual(html, "<p>Code is cool:</p><pre><code>Code\n</code></pre>")
     }
+
+    func testTextModifier() {
+        var parser = MarkdownParser()
+
+        parser.addModifier(Modifier(target: .text) {
+            $0.html.uppercased()
+        })
+
+        let html = parser.html(from: "foo αγω éö")
+
+        XCTAssertEqual(html, "<p>FOO ΑΓΩ ÉÖ</p>")
+    }
+
+    func testTextModifierAffectsLinkText() {
+        var parser = MarkdownParser()
+
+        parser.addModifier(Modifier(target: .text) {
+            $0.html.uppercased()
+        })
+
+        let html = parser.html(from: "foo [αγω](test) éö")
+
+        XCTAssertEqual(html, #"<p>FOO <a href="test">ΑΓΩ</a> ÉÖ</p>"#)
+    }
+
+    func testTextModifierProtectsCodeAndHTML() {
+        var parser = MarkdownParser()
+
+        parser.addModifier(Modifier(target: .text) {
+            $0.html.uppercased()
+        })
+
+        let html = parser.html(from: "foo `αγω` éö <p>foo `αγω` éö</p>")
+
+        XCTAssertEqual(html, #"<p>FOO <code>αγω</code> ÉÖ</p><p>foo `αγω` éö</p>"#)
+    }
 }
 
 extension ModifierTests {
@@ -84,7 +120,10 @@ extension ModifierTests {
             ("testModifierInput", testModifierInput),
             ("testInitializingParserWithModifiers", testInitializingParserWithModifiers),
             ("testAddingModifiers", testAddingModifiers),
-            ("testMultipleModifiersForSameTarget", testMultipleModifiersForSameTarget)
+            ("testMultipleModifiersForSameTarget", testMultipleModifiersForSameTarget),
+            ("testTextModifier", testTextModifier),
+            ("testTextModifierAffectsLinkText", testTextModifierAffectsLinkText),
+            ("testTextModifierProtectsCodeAndHTML", testTextModifierProtectsCodeAndHTML),
         ]
     }
 }


### PR DESCRIPTION
## Summary

This PR allows Modifiers to transform unformatted text—for example, the contents of an `h1` heading, the text of a link, or the bulk of a paragraph.

## Discussion

In my Publish site, I need to examine the text of my markdown files to do some dynamic transformation. For simplicity, imagine I want to provide dynamic stock prices based on ticker symbols (this is a bad example, but bear with me).

So given the markdown `Apple trades under the ticker $AAPL`, I would like to generate:

```html
<p>Apple trades under the ticker AAPL ($324.34 ▲ 6.65 | 2.09%)</p>
```

Currently there doesn't seem to be a clean way to do this in Publish.

## This change

This change adds a `Modifier.Target` case (`.text`) which allows Modifiers to target plain text, so you could write:

```swift
parser.addModifier(Modifier(target: .text) {
    $0.html.replacingOccurrences(of: "$AAPL", with: "AAPL (" + currentTicker + ")")
})
```

## Implications

This is accomplished by extending `Substring` to conform to `HTMLConvertible` and `Modifiable`. It works fine, but I admit it's a little strange at the calling site to request `.html` for a plain string.

Although Ink is smart enough to avoid code blocks and HTML within markdown, the user could still run into problems if they try to add HTML elements in their Modifier. For example, if the user tries to add links to plain text, they should be aware that their incoming text might itself be within another link, so you could accidentally end up with:

```html
<a href="https://apple.com/">View the <a href="https://apple.com/">AAPL</a> site</a>
```

However, this is a danger with any Modifier, so I don't think it's unique to this PR.

Thanks for considering this! 🙏