### PR TITLE
Add support for attributes in links (width, height, etc)

### DIFF
--- a/Sources/Ink/Internal/Attribute.swift
+++ b/Sources/Ink/Internal/Attribute.swift
@@ -1,0 +1,23 @@
+//
+//  Attribute.swift
+//  
+//
+//  Created by Sven A. Schmidt on 22/02/2020.
+//
+
+
+internal struct Attribute: HTMLConvertible {
+    var key: String
+    var value: String
+
+    init?(_ rawValue: String) {
+        let pair = rawValue.split(separator: "=").map(String.init)
+        guard pair.count == 2 else { return nil }
+        key = pair[0]
+        value = pair[1]
+    }
+
+    func html(usingURLs urls: NamedURLCollection, modifiers: ModifierCollection) -> String {
+        "\(key)=\"\(value)\""
+    }
+}

--- a/Sources/Ink/Internal/Image.swift
+++ b/Sources/Ink/Internal/Image.swift
@@ -18,12 +18,19 @@ internal struct Image: Fragment {
               modifiers: ModifierCollection) -> String {
         let url = link.target.url(from: urls)
         var alt = link.text.html(usingURLs: urls, modifiers: modifiers)
+        var attr = link.attributes
+            .map({ $0.html(usingURLs: urls, modifiers: modifiers)})
+            .joined(separator: " ")
 
         if !alt.isEmpty {
             alt = " alt=\"\(alt)\""
         }
 
-        return "<img src=\"\(url)\"\(alt)/>"
+        if !attr.isEmpty {
+            attr = " " + attr
+        }
+
+        return "<img src=\"\(url)\"\(alt)\(attr)/>"
     }
 
     func plainText() -> String {

--- a/Sources/Ink/Internal/Link.swift
+++ b/Sources/Ink/Internal/Link.swift
@@ -20,12 +20,11 @@ internal struct Link: Fragment {
     }
 
     init(url: Substring, text: FormattedText) {
-        let parts = url.unicodeScalars.split(whereSeparator: { CharacterSet.whitespaces.contains($0) })
+        let parts = url.components(separatedBy: CharacterSet.whitespaces)
         if parts.count > 1 {
             self.target = .url(String(parts.first!)[...])
             self.attributes = parts
                 .dropFirst()
-                .map(String.init)
                 .compactMap(Attribute.init)
         } else {
             self.target = .url(url)

--- a/Sources/Ink/Internal/Link.swift
+++ b/Sources/Ink/Internal/Link.swift
@@ -4,11 +4,34 @@
 *  MIT license, see LICENSE file for details
 */
 
+import Foundation
+
+
 internal struct Link: Fragment {
     var modifierTarget: Modifier.Target { .links }
 
     var target: Target
     var text: FormattedText
+    var attributes: [Attribute] = []
+
+    init(target: Target, text: FormattedText) {
+        self.target = target
+        self.text = text
+    }
+
+    init(url: Substring, text: FormattedText) {
+        let parts = url.unicodeScalars.split(whereSeparator: { CharacterSet.whitespaces.contains($0) })
+        if parts.count > 1 {
+            self.target = .url(String(parts.first!)[...])
+            self.attributes = parts
+                .dropFirst()
+                .map(String.init)
+                .compactMap(Attribute.init)
+        } else {
+            self.target = .url(url)
+        }
+        self.text = text
+    }
 
     static func read(using reader: inout Reader) throws -> Link {
         try reader.read("[")
@@ -20,7 +43,7 @@ internal struct Link: Fragment {
         if reader.currentCharacter == "(" {
             reader.advanceIndex()
             let url = try reader.read(until: ")")
-            return Link(target: .url(url), text: text)
+            return Link(url: url, text: text)
         } else {
             try reader.read("[")
             let reference = try reader.read(until: "]")
@@ -32,7 +55,15 @@ internal struct Link: Fragment {
               modifiers: ModifierCollection) -> String {
         let url = target.url(from: urls)
         let title = text.html(usingURLs: urls, modifiers: modifiers)
-        return "<a href=\"\(url)\">\(title)</a>"
+        var attr = attributes
+            .map({ $0.html(usingURLs: urls, modifiers: modifiers)})
+            .joined(separator: " ")
+
+        if !attr.isEmpty {
+            attr = " " + attr
+        }
+
+        return "<a href=\"\(url)\"\(attr)>\(title)</a>"
     }
 
     func plainText() -> String {

--- a/Tests/InkTests/ImageTests.swift
+++ b/Tests/InkTests/ImageTests.swift
@@ -40,6 +40,17 @@ final class ImageTests: XCTestCase {
         let html = MarkdownParser().html(from: "Text ![](url) text")
         XCTAssertEqual(html, #"<p>Text <img src="url"/> text</p>"#)
     }
+
+    func testImageWithSizeAttributes() {
+        do {
+            let html = MarkdownParser().html(from: "![](https://example/image.png width=400)")
+            XCTAssertEqual(html, #"<img src="https://example/image.png" width="400"/>"#)
+        }
+        do {
+            let html = MarkdownParser().html(from: "![](https://example/image.png width=400 height=300)")
+            XCTAssertEqual(html, #"<img src="https://example/image.png" width="400" height="300"/>"#)
+        }
+    }
 }
 
 extension ImageTests {
@@ -49,7 +60,8 @@ extension ImageTests {
             ("testImageWithReference", testImageWithReference),
             ("testImageWithURLAndAltText", testImageWithURLAndAltText),
             ("testImageWithReferenceAndAltText", testImageWithReferenceAndAltText),
-            ("testImageWithinParagraph", testImageWithinParagraph)
+            ("testImageWithinParagraph", testImageWithinParagraph),
+            ("testImageWithSizeAttributes", testImageWithSizeAttributes)
         ]
     }
 }


### PR DESCRIPTION
Note that as I opened this MR I realised that there's #42 which does something similar but for `title`.

This PR here is a bit more general in that it supports any attribute (`title`, `height`, `width`, ...) by looking for `=` separated pairs after a URL and parsing them out into `[Attribute]`.

 However, what it _doesn't_ do is take into account quoted strings properly. I think it would be great to merge the two approaches and get generic support for `Attribute` parsing with proper quoting.

The original motivation for this particular change here is that some Markdown editors (Ulyssus for instance) allow size attributes on images, which get translated into

```
![](https://example/image.png width=400)
```

on export.

Currently, this gets translated into this broken html:

```
<img src="https://example/image.png width=400"/>
```
