### PR TITLE
Adding id to Header Tag

### DIFF
--- a/Sources/Ink/Internal/Heading.swift
+++ b/Sources/Ink/Internal/Heading.swift
@@ -26,7 +26,7 @@ internal struct Heading: Fragment {
         )
 
         let tagName = "h\(level)"
-        return "<\(tagName)>\(body)</\(tagName)>"
+        return "<\(tagName) id=\"\(body)\">\(body)</\(tagName)>"
     }
 
     func plainText() -> String {


### PR DESCRIPTION
This PR is still a work in progress. But submitting it for now just to gather feedback and ensure @JohnSundell and the rest of the community supports this change before pressing forward and dedicating a lot of time to it.

A lot of other markdown parsers set tags for headers so that it's easy to add hyperlinks to different parts of the page. The goal of this PR is to add that functionality to Ink.

I do have `Allow edits from maintainers.` checked, so any maintainers of this repo can push to my branch if you would like to contribute to this PR.

---

Todo Items:

- [ ] Add support for spaces and special characters in header (ensure they work correctly with id)
- [ ] Add/Update tests