### PR TITLE
Add support for most common nested elements in block quotes

### DIFF
--- a/Sources/Ink/Internal/Blockquote.swift
+++ b/Sources/Ink/Internal/Blockquote.swift
@@ -7,23 +7,13 @@
 internal struct Blockquote: Fragment {
     var modifierTarget: Modifier.Target { .blockquotes }
 
-    private var paragraphs = [innerParagraph]()
+    private var items = [Fragment]()
 
     static func read(using reader: inout Reader) throws -> Blockquote {
         // This is the Blockquote object we will return.
         var blockquote = Blockquote()
-        // This tracks whether the next blockquote line will start a new paragraph.
-        var startNewParagraph = true
         // This gets us to the first blockquote in the document.
         try reader.read(">")
-
-        func addTextToLastParagraph() throws {
-            try require(!blockquote.paragraphs.isEmpty)
-            let text = FormattedText.readLine(using: &reader)
-            var lastParagraph = blockquote.paragraphs.removeLast()
-            lastParagraph.text.append(text, separator: " ")
-            blockquote.paragraphs.append(lastParagraph)
-        }
 
         // Ensures that currentCharacter refers to the first angle bracket.
         reader.rewindIndex()
@@ -43,22 +33,16 @@ internal struct Blockquote: Fragment {
                 }
                 let nextChar = reader.currentCharacter
                 switch nextChar {
+                case "#":
+                    let heading = try Heading.read(using: &reader)
+                    blockquote.items.append(heading)
+                    // Heading does not consume the trailing newline.
+                    reader.advanceIndex()
                 case \.isNewline:
-                    // A new line after the angle bracket means that the next line will
-                    // belong to a new paragraph.
-                    startNewParagraph = true
                     reader.advanceIndex()
                 default:
-                    if startNewParagraph {
-                        // Append this line to the blockquote’s array of paragraphs.
-                        blockquote.paragraphs.append(
-                            innerParagraph(text: FormattedText.readLine(using: &reader))
-                        )
-                    } else {
-                        // Append this line to the already existing paragraph.
-                        try addTextToLastParagraph()
-                    }
-                    startNewParagraph = false
+                    blockquote.items.append(
+                        Paragraph.read(using: &reader, ignorePrefix: ">"))
                 }
             case \.isNewline:
                 return blockquote
@@ -72,31 +56,16 @@ internal struct Blockquote: Fragment {
     func html(usingURLs urls: NamedURLCollection,
               modifiers: ModifierCollection) -> String {
         // First get the HTML representation of the paragraphs.
-        let body = paragraphs.reduce(into: "") { html, paragraph in
-            html.append(paragraph.html(usingURLs: urls, modifiers: modifiers))
+        let body = items.reduce(into: "") { html, item in
+            html.append(item.html(usingURLs: urls, modifiers: modifiers))
         }
         // Now wrap everything in a blockquote tag.
         return "<blockquote>\(body)</blockquote>"
     }
 
     func plainText() -> String {
-        return paragraphs.reduce(into: "") { string, paragraph in
-            string.append(paragraph.text.plainText())
-        }
-    }
-}
-
-extension Blockquote {
-    // The existing Paragraph object’s text property is marked private, so we can’t
-    // access it from outside of that object. It was therefore necessary to add this
-    // paragraph struct to Blockquote.
-    fileprivate struct innerParagraph: HTMLConvertible {
-        var text: FormattedText
-
-        func html(usingURLs urls: NamedURLCollection,
-                  modifiers: ModifierCollection) -> String {
-            let textHTML = text.html(usingURLs: urls, modifiers: modifiers)
-            return "<p>\(textHTML)</p>"
+        return items.reduce(into: "") { string, item in
+            string.append(item.plainText())
         }
     }
 }

--- a/Sources/Ink/Internal/Blockquote.swift
+++ b/Sources/Ink/Internal/Blockquote.swift
@@ -38,6 +38,9 @@ internal struct Blockquote: Fragment {
                     blockquote.items.append(heading)
                     // Heading does not consume the trailing newline.
                     reader.advanceIndex()
+                case "-", "*", "+", \.isNumber:
+                    let list = try List.read(using: &reader, ignorePrefix: ">")
+                    blockquote.items.append(list)
                 case \.isNewline:
                     reader.advanceIndex()
                 default:

--- a/Sources/Ink/Internal/Blockquote.swift
+++ b/Sources/Ink/Internal/Blockquote.swift
@@ -16,51 +16,39 @@ internal struct Blockquote: Fragment {
     static func read(using reader: inout Reader, ignorePrefix: String?) throws -> Blockquote {
         var blockquote = Blockquote()
         try reader.read(">")
-
-        // Ensures that currentCharacter refers to the first angle bracket.
-        reader.rewindIndex()
-        // These defaults were chosen arbitrarily to avoid activating the ignore case
-        // when not needed.
-        let ignoreFirstChar = ignorePrefix?.first ?? "ñ"
-        let ignorePrefixString = ignorePrefix ?? ""
+        reader.rewindUntilBeginningOfLine()
         while !reader.didReachEnd {
-            let previousCharacter = reader.previousCharacter ?? "\n"
-            let lookAhead = reader.lookAheadAtCharacters(ignorePrefixString.count) ?? "⫝"
-            // The nested switch can advance the reader, causing currentCharacter to
-            // change by the time control returns to the outer switch; best to lock down
-            // the first character.
+
+            if let ignorePrefix = ignorePrefix {
+                if let lookAhead = reader.lookAheadAtCharacters(ignorePrefix.count) {
+                    if lookAhead == ignorePrefix {
+                        for _ in 0..<ignorePrefix.count {
+                            reader.advanceIndex()
+                        }
+                        reader.discardWhitespaces()
+                    }
+                }
+            }
+
             let firstChar = reader.currentCharacter
             switch firstChar {
-            case ignoreFirstChar where previousCharacter.isNewline && lookAhead == ignorePrefixString:
-                for _ in 0..<ignorePrefixString.count {
-                    reader.advanceIndex()
-                }
-                do {
-                    try reader.readWhitespaces()
-                } catch is Reader.Error { }
             case ">":
-                // Move past the angle bracket.
-                reader.advanceIndex()
-                // Check the first non-space character after the angle bracket for block-
-                // level elements.
-                do {
-                    try reader.readWhitespaces()
-                } catch is Reader.Error { }  // Not a problem if there is no whitespace.
+                reader.advanceIndex()  // Move past the angle bracket.
+                reader.discardWhitespaces()
                 let nextChar = reader.currentCharacter
                 switch nextChar {
                 case "#":
                     let heading = try Heading.read(using: &reader)
                     blockquote.items.append(heading)
-                    // Heading does not consume the trailing newline.
-                    reader.advanceIndex()
+                    if reader.currentCharacter == "\n" {
+                        reader.advanceIndex()
+                    }
                 case "-", "*", "+", \.isNumber:
                     let list = try List.read(using: &reader, ignorePrefix: ">")
                     blockquote.items.append(list)
                 case ">":
-                    reader.rewindIndex()
-                    reader.rewindIndex()
-                    let innerBlockquote = try Blockquote.read(using: &reader, ignorePrefix: ">")
-                    blockquote.items.append(innerBlockquote)
+                    let nestedBlockquote = try Blockquote.read(using: &reader, ignorePrefix: ">")
+                    blockquote.items.append(nestedBlockquote)
                 case \.isNewline:
                     reader.advanceIndex()
                 default:

--- a/Sources/Ink/Internal/List.swift
+++ b/Sources/Ink/Internal/List.swift
@@ -15,8 +15,13 @@ internal struct List: Fragment {
         try read(using: &reader, indentationLength: 0)
     }
 
+    static func read(using reader: inout Reader, ignorePrefix: String? = nil) throws -> List {
+        try read(using: &reader, indentationLength: 0, ignorePrefix: ignorePrefix)
+    }
+
     private static func read(using reader: inout Reader,
-                             indentationLength: Int) throws -> List {
+                             indentationLength: Int,
+                             ignorePrefix: String? = nil) throws -> List {
         let startIndex = reader.currentIndex
         let isOrdered = reader.currentCharacter.isNumber
 
@@ -43,8 +48,19 @@ internal struct List: Fragment {
             list.items.append(lastItem)
         }
 
+        // These defaults were chosen arbitrarily to avoid activating the ignore case
+        // when not needed.
+        let ignoreFirstChar = ignorePrefix?.first ?? "ñ"
+        let ignorePrefixString = ignorePrefix ?? ""
         while !reader.didReachEnd {
+            let previousCharacter = reader.previousCharacter ?? "\n"
+            let lookAhead = reader.lookAheadAtCharacters(ignorePrefixString.count) ?? "⫝"
             switch reader.currentCharacter {
+            case ignoreFirstChar where previousCharacter.isNewline && lookAhead == ignorePrefixString:
+                for _ in 0..<ignorePrefixString.count {
+                    reader.advanceIndex()
+                }
+                try reader.readWhitespaces()
             case \.isNewline:
                 return list
             case \.isWhitespace:

--- a/Sources/Ink/Internal/List.swift
+++ b/Sources/Ink/Internal/List.swift
@@ -48,19 +48,20 @@ internal struct List: Fragment {
             list.items.append(lastItem)
         }
 
-        // These defaults were chosen arbitrarily to avoid activating the ignore case
-        // when not needed.
-        let ignoreFirstChar = ignorePrefix?.first ?? "ñ"
-        let ignorePrefixString = ignorePrefix ?? ""
         while !reader.didReachEnd {
-            let previousCharacter = reader.previousCharacter ?? "\n"
-            let lookAhead = reader.lookAheadAtCharacters(ignorePrefixString.count) ?? "⫝"
-            switch reader.currentCharacter {
-            case ignoreFirstChar where previousCharacter.isNewline && lookAhead == ignorePrefixString:
-                for _ in 0..<ignorePrefixString.count {
-                    reader.advanceIndex()
+
+            if let ignorePrefix = ignorePrefix {
+                if let lookAhead = reader.lookAheadAtCharacters(ignorePrefix.count) {
+                    if lookAhead == ignorePrefix {
+                        for _ in 0..<ignorePrefix.count {
+                            reader.advanceIndex()
+                        }
+                        reader.discardWhitespaces()
+                    }
                 }
-                try reader.readWhitespaces()
+            }
+
+            switch reader.currentCharacter {
             case \.isNewline:
                 return list
             case \.isWhitespace:

--- a/Sources/Ink/Internal/Paragraph.swift
+++ b/Sources/Ink/Internal/Paragraph.swift
@@ -13,6 +13,12 @@ internal struct Paragraph: Fragment {
         return Paragraph(text: .read(using: &reader))
     }
 
+    static func read(using reader: inout Reader, ignorePrefix: String) -> Paragraph {
+        return Paragraph(text: .read(using: &reader,
+                                     terminator: nil,
+                                     ignorePrefix: ignorePrefix))
+    }
+
     func html(usingURLs urls: NamedURLCollection,
               modifiers: ModifierCollection) -> String {
         let body = text.html(usingURLs: urls, modifiers: modifiers)

--- a/Sources/Ink/Internal/Reader.swift
+++ b/Sources/Ink/Internal/Reader.swift
@@ -18,10 +18,12 @@ extension Reader {
     struct Error: Swift.Error {}
 
     var didReachEnd: Bool { currentIndex == endIndex }
+    var didReachBegining: Bool { currentIndex == startIndex }
     var previousCharacter: Character? { lookBehindAtPreviousCharacter() }
     var currentCharacter: Character { string[currentIndex] }
     var nextCharacter: Character? { lookAheadAtNextCharacter() }
     var endIndex: String.Index { string.endIndex }
+    var startIndex: String.Index { string.startIndex }
 
     func characters(in range: Range<String.Index>) -> Substring {
         return string[range]
@@ -157,6 +159,21 @@ extension Reader {
 
     mutating func rewindIndex() {
         currentIndex = string.index(before: currentIndex)
+    }
+
+    mutating func rewindUntilBeginningOfLine() {
+        guard !currentCharacter.isNewline else { return }
+        while !didReachBegining {
+            if let prevChar = previousCharacter {
+                if !prevChar.isNewline {
+                    rewindIndex()
+                } else {
+                    return
+                }
+            } else {
+                return
+            }
+        }
     }
 
     mutating func moveToIndex(_ index: String.Index) {

--- a/Sources/Ink/Internal/Reader.swift
+++ b/Sources/Ink/Internal/Reader.swift
@@ -162,6 +162,18 @@ extension Reader {
     mutating func moveToIndex(_ index: String.Index) {
         currentIndex = index
     }
+
+    func lookAheadAtCharacters(_ count: Int) -> Substring? {
+        // Returns a substring of the next n characters without advancing the current
+        // index.
+        guard !didReachEnd else { return nil }
+        if let endIndex = string.index(currentIndex,
+                                       offsetBy: count,
+                                       limitedBy: string.endIndex) {
+            return string[currentIndex..<endIndex]
+        }
+        return nil
+    }
 }
 
 private extension Reader {

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -128,14 +128,11 @@ final class TextFormattingTests: XCTestCase {
         XCTAssertEqual(html, "<blockquote><p>One Two Three</p></blockquote>")
     }
 
-    func testH1InBlockquote() {
-        // https://spec.commonmark.org/0.29/#block-quotes Example 198
+    func testNestedBlockquote() {
         let html = MarkdownParser().html(from: """
-            > # Foo
-            > bar
-            > baz
+            > > Foo
             """)
-        XCTAssertEqual(html, "<blockquote><h1>Foo</h1><p>bar baz</p></blockquote>")
+        XCTAssertEqual(html, "<blockquote><blockquote><p>Foo</p></blockquote></blockquote>")
     }
 
     func testUnorderedListInBlockquote() {
@@ -144,6 +141,16 @@ final class TextFormattingTests: XCTestCase {
             > * Second Item
             """)
         XCTAssertEqual(html, "<blockquote><ul><li>First Item</li><li>Second Item</li></ul></blockquote>")
+    }
+
+    func testH1InBlockquote() {
+        // https://spec.commonmark.org/0.29/#block-quotes Example 198
+        let html = MarkdownParser().html(from: """
+            > # Foo
+            > bar
+            > baz
+            """)
+        XCTAssertEqual(html, "<blockquote><h1>Foo</h1><p>bar baz</p></blockquote>")
     }
 
     func testMultiParagraphBlockquote() {
@@ -241,6 +248,7 @@ extension TextFormattingTests {
             ("testEncodingSpecialCharacters", testEncodingSpecialCharacters),
             ("testSingleLineBlockquote", testSingleLineBlockquote),
             ("testMultiLineBlockquote", testMultiLineBlockquote),
+            ("testNestedBlockquote", testNestedBlockquote),
             ("testH1InBlockquote", testH1InBlockquote),
             ("testUnorderedListInBlockquote", testUnorderedListInBlockquote),
             ("testMultiParagraphBlockquote", testMultiParagraphBlockquote),

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -118,16 +118,6 @@ final class TextFormattingTests: XCTestCase {
         XCTAssertEqual(html, "<blockquote><p>Hello, world!</p></blockquote>")
     }
 
-    func testMultiLineBlockquote() {
-        let html = MarkdownParser().html(from: """
-        > One
-        > Two
-        > Three
-        """)
-
-        XCTAssertEqual(html, "<blockquote><p>One Two Three</p></blockquote>")
-    }
-
     func testNestedBlockquote() {
         let html = MarkdownParser().html(from: """
             > > Foo
@@ -151,6 +141,30 @@ final class TextFormattingTests: XCTestCase {
             > baz
             """)
         XCTAssertEqual(html, "<blockquote><h1>Foo</h1><p>bar baz</p></blockquote>")
+    }
+
+    func testBlankLineInBlockquoteSeparates() {
+        // https://spec.commonmark.org/0.29/#block-quotes Example 212
+        // According to the CommonMark spec, this should produce two blockquote elements.
+        let html = MarkdownParser().html(from: """
+            > foo
+
+            > bar
+            """)
+        XCTAssertEqual(html, "<blockquote><p>foo</p></blockquote><blockquote><p>bar</p></blockquote>")
+    }
+
+    func testMultiLineBlockquote() {
+        // https://spec.commonmark.org/0.29/#block-quotes Example 213
+        // According to the CommonMark spec, this should produce one blockquote element
+        // with one paragraph.
+        let html = MarkdownParser().html(from: """
+        > One
+        > Two
+        > Three
+        """)
+
+        XCTAssertEqual(html, "<blockquote><p>One Two Three</p></blockquote>")
     }
 
     func testMultiParagraphBlockquote() {
@@ -251,6 +265,7 @@ extension TextFormattingTests {
             ("testNestedBlockquote", testNestedBlockquote),
             ("testH1InBlockquote", testH1InBlockquote),
             ("testUnorderedListInBlockquote", testUnorderedListInBlockquote),
+            ("testBlankLineInBlockquoteSeparates", testBlankLineInBlockquoteSeparates),
             ("testMultiParagraphBlockquote", testMultiParagraphBlockquote),
             ("testMultiLineMultiParagraphBlockquote", testMultiLineMultiParagraphBlockquote),
             ("testEscapingSymbolsWithBackslash", testEscapingSymbolsWithBackslash),

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -138,6 +138,14 @@ final class TextFormattingTests: XCTestCase {
         XCTAssertEqual(html, "<blockquote><h1>Foo</h1><p>bar baz</p></blockquote>")
     }
 
+    func testUnorderedListInBlockquote() {
+        let html = MarkdownParser().html(from: """
+            > * First Item
+            > * Second Item
+            """)
+        XCTAssertEqual(html, "<blockquote><ul><li>First Item</li><li>Second Item</li></ul></blockquote>")
+    }
+
     func testMultiParagraphBlockquote() {
         // https://spec.commonmark.org/0.29/#block-quotes Example 214
         // According to the CommonMark spec, this should produce one blockquote element
@@ -233,9 +241,10 @@ extension TextFormattingTests {
             ("testEncodingSpecialCharacters", testEncodingSpecialCharacters),
             ("testSingleLineBlockquote", testSingleLineBlockquote),
             ("testMultiLineBlockquote", testMultiLineBlockquote),
+            ("testH1InBlockquote", testH1InBlockquote),
+            ("testUnorderedListInBlockquote", testUnorderedListInBlockquote),
             ("testMultiParagraphBlockquote", testMultiParagraphBlockquote),
             ("testMultiLineMultiParagraphBlockquote", testMultiLineMultiParagraphBlockquote),
-            ("testH1InBlockquote", testH1InBlockquote),
             ("testEscapingSymbolsWithBackslash", testEscapingSymbolsWithBackslash),
             ("testDoubleSpacedHardLinebreak", testDoubleSpacedHardLinebreak),
             ("testEscapedHardLinebreak", testEscapedHardLinebreak)

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -4,8 +4,8 @@
 *  MIT license, see LICENSE file for details
 */
 
-import XCTest
 import Ink
+import XCTest
 
 final class TextFormattingTests: XCTestCase {
     func testParagraph() {
@@ -128,6 +128,52 @@ final class TextFormattingTests: XCTestCase {
         XCTAssertEqual(html, "<blockquote><p>One Two Three</p></blockquote>")
     }
 
+    func testMultiParagraphBlockquote() {
+        // https://spec.commonmark.org/0.29/#block-quotes Example 214
+        // According to the CommonMark spec, this should produce one blockquote element
+        // containing two paragraphs.
+        let html = MarkdownParser().html(
+            from: """
+                > foo
+                >
+                > bar
+                """)
+
+        XCTAssertEqual(
+            html,
+            "<blockquote><p>foo</p><p>bar</p></blockquote>"
+        )
+    }
+
+    func testMultiLineMultiParagraphBlockquote() {
+        // Related to Example 214 above, but this test ensures that multi-line paragraphs
+        // are preserved. Text borrowed from the swift.org homepage.
+        let html = MarkdownParser().html(
+            from: """
+                > Welcome to the Swift community. Together we are working to build a
+                > programming language to empower everyone to turn their ideas into apps
+                > on any platform.
+                >
+                > Announced in 2014, the Swift programming language has quickly become
+                > one of the fastest growing languages in history. Swift makes it easy to
+                > write software that is incredibly fast and safe by design. Our goals
+                > for Swift are ambitious: we want to make programming simple things
+                > easy, and difficult things possible.
+                """)
+
+        XCTAssertEqual(
+            html,
+            "<blockquote><p>Welcome to the Swift community. Together we are working " +
+            "to build a programming language to empower everyone to turn their ideas " +
+            "into apps on any platform.</p><p>Announced in 2014, the Swift " +
+            "programming language has quickly become one of the fastest growing " +
+            "languages in history. Swift makes it easy to write software that is " +
+            "incredibly fast and safe by design. Our goals for Swift are ambitious: " +
+            "we want to make programming simple things easy, and difficult things " +
+            "possible.</p></blockquote>"
+        )
+    }
+
     func testEscapingSymbolsWithBackslash() {
         let html = MarkdownParser().html(from: """
         \\# Not a title
@@ -176,6 +222,8 @@ extension TextFormattingTests {
             ("testEncodingSpecialCharacters", testEncodingSpecialCharacters),
             ("testSingleLineBlockquote", testSingleLineBlockquote),
             ("testMultiLineBlockquote", testMultiLineBlockquote),
+            ("testMultiParagraphBlockquote", testMultiParagraphBlockquote),
+            ("testMultiLineMultiParagraphBlockquote", testMultiLineMultiParagraphBlockquote),
             ("testEscapingSymbolsWithBackslash", testEscapingSymbolsWithBackslash),
             ("testDoubleSpacedHardLinebreak", testDoubleSpacedHardLinebreak),
             ("testEscapedHardLinebreak", testEscapedHardLinebreak)

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -128,6 +128,16 @@ final class TextFormattingTests: XCTestCase {
         XCTAssertEqual(html, "<blockquote><p>One Two Three</p></blockquote>")
     }
 
+    func testH1InBlockquote() {
+        // https://spec.commonmark.org/0.29/#block-quotes Example 198
+        let html = MarkdownParser().html(from: """
+            > # Foo
+            > bar
+            > baz
+            """)
+        XCTAssertEqual(html, "<blockquote><h1>Foo</h1><p>bar baz</p></blockquote>")
+    }
+
     func testMultiParagraphBlockquote() {
         // https://spec.commonmark.org/0.29/#block-quotes Example 214
         // According to the CommonMark spec, this should produce one blockquote element
@@ -162,15 +172,16 @@ final class TextFormattingTests: XCTestCase {
                 """)
 
         XCTAssertEqual(
-            html,
-            "<blockquote><p>Welcome to the Swift community. Together we are working " +
-            "to build a programming language to empower everyone to turn their ideas " +
-            "into apps on any platform.</p><p>Announced in 2014, the Swift " +
-            "programming language has quickly become one of the fastest growing " +
-            "languages in history. Swift makes it easy to write software that is " +
-            "incredibly fast and safe by design. Our goals for Swift are ambitious: " +
-            "we want to make programming simple things easy, and difficult things " +
-            "possible.</p></blockquote>"
+            html, """
+            <blockquote><p>Welcome to the Swift community. Together we are working \
+            to build a programming language to empower everyone to turn their ideas \
+            into apps on any platform.</p><p>Announced in 2014, the Swift \
+            programming language has quickly become one of the fastest growing \
+            languages in history. Swift makes it easy to write software that is \
+            incredibly fast and safe by design. Our goals for Swift are ambitious: \
+            we want to make programming simple things easy, and difficult things \
+            possible.</p></blockquote>
+            """
         )
     }
 
@@ -224,6 +235,7 @@ extension TextFormattingTests {
             ("testMultiLineBlockquote", testMultiLineBlockquote),
             ("testMultiParagraphBlockquote", testMultiParagraphBlockquote),
             ("testMultiLineMultiParagraphBlockquote", testMultiLineMultiParagraphBlockquote),
+            ("testH1InBlockquote", testH1InBlockquote),
             ("testEscapingSymbolsWithBackslash", testEscapingSymbolsWithBackslash),
             ("testDoubleSpacedHardLinebreak", testDoubleSpacedHardLinebreak),
             ("testEscapedHardLinebreak", testEscapedHardLinebreak)


### PR DESCRIPTION
I've had a go at updating Ink to support what I think are the HTML elements most commonly nested inside block quotes. I'm relatively new to Swift, so please let me know if you have any comments or suggestions.