### PR TITLE
Added support for matching parentheses in link URLs

### DIFF
--- a/Sources/Ink/Internal/Link.swift
+++ b/Sources/Ink/Internal/Link.swift
@@ -19,7 +19,15 @@ internal struct Link: Fragment {
 
         if reader.currentCharacter == "(" {
             reader.advanceIndex()
-            let url = try reader.read(until: ")")
+            reader.discardWhitespaces()
+            var url = try reader.read(until: ")")
+            var parenCount = url.filter { $0 == "(" }.count
+            while parenCount > 0 {
+                parenCount -= 1
+                let urlExtra = try reader.read(until: ")")
+                parenCount += urlExtra.filter { $0 == "(" }.count
+                url += ")" + urlExtra
+            }
             return Link(target: .url(url), text: text)
         } else {
             try reader.read("[")

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -13,6 +13,11 @@ final class LinkTests: XCTestCase {
         XCTAssertEqual(html, #"<p><a href="url">Title</a></p>"#)
     }
 
+    func testLinkWithURLIncludingParentheses() {
+        let html = MarkdownParser().html(from: "[Title](https://en.wikipedia.org/wiki/String_(computer_science))")
+        XCTAssertEqual(html, #"<p><a href="https://en.wikipedia.org/wiki/String_(computer_science)">Title</a></p>"#)
+    }
+
     func testLinkWithReference() {
         let html = MarkdownParser().html(from: """
         [Title][url]
@@ -75,6 +80,7 @@ extension LinkTests {
     static var allTests: Linux.TestList<LinkTests> {
         return [
             ("testLinkWithURL", testLinkWithURL),
+            ("testLinkWithURLIncludingParentheses", testLinkWithURLIncludingParentheses),
             ("testLinkWithReference", testLinkWithReference),
             ("testCaseMismatchedLinkWithReference", testCaseMismatchedLinkWithReference),
             ("testNumericLinkWithReference", testNumericLinkWithReference),


### PR DESCRIPTION
Markdown should support inline links that contain matching pairs of parentheses, eg `[my link](http://example.com/link_(with_parens))`. These are quite common on Wikipedia for example.

The current implementation is not ideal because of the limitations of Reader, maybe it would be better to add support in there for escaped or balanced pairs of characters?

Also don't like the `.filter.count` but it seems `Substring` doesn't support `count(where:)`