### PR TITLE
Support multiple table headers

### DIFF
--- a/Sources/Ink/Internal/Table.swift
+++ b/Sources/Ink/Internal/Table.swift
@@ -9,7 +9,7 @@ import Foundation
 struct Table: Fragment {
     var modifierTarget: Modifier.Target { .tables }
 
-    private var header: [Row]? // There can be multiple header rows in a table.
+    private var headers: [Row]? // There can be multiple header rows in a table.
     private var rows = [Row]()
     private var columnCount = 0
     private var columnAlignments = [ColumnAlignment]()
@@ -37,8 +37,8 @@ struct Table: Fragment {
         var html = ""
         let render: () -> String = { "<table>\(html)</table>" }
 
-        if let header = header {
-            for row in header {
+        if let headers = headers {
+            for row in headers {
                 let rowHTML = self.html(
                     forRow: row,
                     cellElementName: "th",
@@ -73,8 +73,8 @@ struct Table: Fragment {
     func plainText() -> String {
         var text = ""
         
-        if let header = header {
-            for row in header {
+        if let headers = headers {
+            for row in headers {
                 if !text.isEmpty { text.append("\n") }
                 text.append(plainText(forRow: row))
             }
@@ -163,7 +163,7 @@ private extension Table {
         
         var headers = [Row]()
         headers.append(contentsOf: rows[0..<alignmentRow])
-        header = headers
+        self.headers = headers
         columnAlignments = alignments
         rows.removeSubrange(0...alignmentRow)
     }

--- a/Sources/Ink/Internal/Table.swift
+++ b/Sources/Ink/Internal/Table.swift
@@ -9,7 +9,7 @@ import Foundation
 struct Table: Fragment {
     var modifierTarget: Modifier.Target { .tables }
 
-    private var header: Row?
+    private var header: [Row]? // There can be multiple header rows in a table.
     private var rows = [Row]()
     private var columnCount = 0
     private var columnAlignments = [ColumnAlignment]()
@@ -38,14 +38,15 @@ struct Table: Fragment {
         let render: () -> String = { "<table>\(html)</table>" }
 
         if let header = header {
-            let rowHTML = self.html(
-                forRow: header,
-                cellElementName: "th",
-                urls: urls,
-                modifiers: modifiers
-            )
-
-            html.append("<thead>\(rowHTML)</thead>")
+            for row in header {
+                let rowHTML = self.html(
+                    forRow: row,
+                    cellElementName: "th",
+                    urls: urls,
+                    modifiers: modifiers
+                )
+                html.append("<thead>\(rowHTML)</thead>")
+            }
         }
 
         guard !rows.isEmpty else {
@@ -70,7 +71,14 @@ struct Table: Fragment {
     }
 
     func plainText() -> String {
-        var text = header.map(plainText) ?? ""
+        var text = ""
+        
+        if let header = header {
+            for row in header {
+                if !text.isEmpty { text.append("\n") }
+                text.append(plainText(forRow: row))
+            }
+        }
 
         for row in rows {
             if !text.isEmpty { text.append("\n") }
@@ -107,15 +115,43 @@ private extension Table {
             }
         }
     }
+    
+    /// This method is to determine where the format row is located in the Table.
+    /// - Returns: Int? If a value is returned it should be the index for the formatting row.
+    func findHeaderAlignmentRow() -> Int? {
+        var result : Int? = nil
+        
+        let textPredicate = Self.allowedHeaderCharacters.contains
 
+        for (index, row) in rows.enumerated() {
+            if index > 0 {
+                // see if the current row is all column alignment cells
+                var goodRow = true
+                for cell in row {
+                    let text = cell.plainText()
+
+                    if !text.allSatisfy(textPredicate) {
+                        goodRow = false
+                        break
+                    }
+                }
+                if goodRow {
+                    result = index
+                }
+            }
+        }
+        return result
+    }
+    
     mutating func formHeaderAndColumnAlignmentsIfNeeded() {
         guard rows.count > 1 else { return }
-        guard rows[0].count == rows[1].count else { return }
+        
+        guard let alignmentRow = findHeaderAlignmentRow(), rows[0].count == rows[alignmentRow].count else { return }
 
         let textPredicate = Self.allowedHeaderCharacters.contains
         var alignments = [ColumnAlignment]()
 
-        for cell in rows[1] {
+        for cell in rows[alignmentRow] {
             let text = cell.plainText()
 
             guard text.allSatisfy(textPredicate) else {
@@ -124,10 +160,12 @@ private extension Table {
 
             alignments.append(parseColumnAlignment(from: text))
         }
-
-        header = rows[0]
+        
+        var headers = [Row]()
+        headers.append(contentsOf: rows[0..<alignmentRow])
+        header = headers
         columnAlignments = alignments
-        rows.removeSubrange(0...1)
+        rows.removeSubrange(0...alignmentRow)
     }
 
     func parseColumnAlignment(from text: String) -> ColumnAlignment {

--- a/Tests/InkTests/TableTests.swift
+++ b/Tests/InkTests/TableTests.swift
@@ -41,6 +41,28 @@ final class TableTests: XCTestCase {
         """)
     }
 
+    func testTableWithMultipleHeaderRows() {
+        let html = MarkdownParser().html(from: """
+        | HeaderA | HeaderB | HeaderC |
+        | HeaderD | HeaderE | HeaderF |
+        | ------- | ------- | ------- |
+        | CellA1  | CellB1  | CellC1  |
+        | CellA2  | CellB2  | CellC2  |
+        """)
+
+        XCTAssertEqual(html, """
+        <table>\
+        <thead><tr><th>HeaderA</th><th>HeaderB</th><th>HeaderC</th></tr></thead>\
+        <thead><tr><th>HeaderD</th><th>HeaderE</th><th>HeaderF</th></tr></thead>\
+        <tbody>\
+        <tr><td>CellA1</td><td>CellB1</td><td>CellC1</td></tr>\
+        <tr><td>CellA2</td><td>CellB2</td><td>CellC2</td></tr>\
+        </tbody>\
+        </table>
+        """)
+    }
+
+    
     func testTableWithUnalignedColumns() {
         let html = MarkdownParser().html(from: """
         | HeaderA                        | HeaderB    | HeaderC |
@@ -210,6 +232,7 @@ extension TableTests {
         return [
             ("testTableWithoutHeader", testTableWithoutHeader),
             ("testTableWithHeader", testTableWithHeader),
+            ("testTableWithMultipleHeaderRows", testTableWithMultipleHeaderRows),
             ("testTableWithUnalignedColumns", testTableWithUnalignedColumns),
             ("testTableWithOnlyHeader", testTableWithOnlyHeader),
             ("testIncompleteTable", testIncompleteTable),


### PR DESCRIPTION
Hi John, 

I appreciate you open sourcing this Swift Package!  I had a need for it to convert a markdown document I'm creating at work into HTML.  This was just about the right ticket for me.  One issue I ran into, which the commercial application products `Byword` and `iA Writer` seem to support is that you can have multiple header rows in a Table.  Ink doesn't support that.  It's hard coded to only accept one row as the header.

I've updated the code, to add this functionality.  

I think they're fairly lightweight changes:  
* Changed the Table property `header` to `headers`, and converted its type from a `Row?` to `[Row]?`.  
* Updated the rest of the code to then handle the case of having multiple header rows in the table.  
* I added a new function `findHeaderAlignmentRow()` to find where the row is for the header separator, and alignment hints in markdown.  
* Added a new Test Case in your unit tests to show this working in a general sense.

This update seems to be working well for me now.  So I thought I'd send a PR back to you with these changes.

Thanks for this project!  Nice and simple to integrate with, and was simple enough to troubleshoot and fix the problem I ran into.

Scott Tury  