### PR TITLE
Improve multiple depth levels list parsing

### DIFF
--- a/Sources/Ink/Internal/List.swift
+++ b/Sources/Ink/Internal/List.swift
@@ -53,15 +53,15 @@ internal struct List: Fragment {
                     continue
                 }
 
+                let fallbackIndex = reader.currentIndex
                 let itemIndentationLength = try reader.readWhitespaces().count
 
                 if itemIndentationLength < indentationLength {
+                    reader.moveToIndex(fallbackIndex)
                     return list
                 } else if itemIndentationLength == indentationLength {
                     continue
                 }
-
-                let fallbackIndex = reader.currentIndex
 
                 do {
                     let nestedList = try List.read(
@@ -72,6 +72,22 @@ internal struct List: Fragment {
                     var lastItem = list.items.removeLast()
                     lastItem.nestedList = nestedList
                     list.items.append(lastItem)
+
+                    if !reader.didReachEnd {
+                        switch (indentationLength, reader.currentCharacter) {
+                        case (0, _): continue
+                        case (_, \.isWhitespace):
+                            let fallbackIndex = reader.currentIndex
+                            let itemIndentationLength = try reader.readWhitespaces().count
+                            if itemIndentationLength == indentationLength {
+                                continue
+                            } else {
+                                reader.moveToIndex(fallbackIndex)
+                                return list
+                            }
+                        case (_, _): return list
+                        }
+                    }
                 } catch {
                     reader.moveToIndex(fallbackIndex)
                     try addTextToLastItem()
@@ -114,6 +130,14 @@ internal struct List: Fragment {
                 reader.advanceIndex()
                 try reader.readWhitespaces()
                 list.items.append(Item(text: .readLine(using: &reader)))
+
+                if !reader.didReachEnd {
+                    switch (indentationLength, reader.currentCharacter) {
+                    case (0, _): continue
+                    case (_, \.isWhitespace): continue
+                    case (_, _): return list
+                    }
+                }
             default:
                 try addTextToLastItem()
             }

--- a/Tests/InkTests/ListTests.swift
+++ b/Tests/InkTests/ListTests.swift
@@ -124,6 +124,49 @@ final class ListTests: XCTestCase {
         XCTAssertEqual(html, expectedComponents.joined())
     }
 
+    func testUnorderedListWithFourLevelsNestedList() {
+        let html = MarkdownParser().html(from: """
+        - A
+            - A1
+                - A11
+                    - A111
+            - B1
+                - B11
+            - C1
+                - C11
+        """)
+
+        let expectedComponents: [String] = [
+            "<ul>",
+                "<li>A",
+                    "<ul>",
+                        "<li>A1",
+                            "<ul>",
+                                "<li>A11",
+                                    "<ul>",
+                                        "<li>A111</li>",
+                                    "</ul>",
+                                "</li>",
+                            "</ul>",
+                        "</li>",
+                        "<li>B1",
+                            "<ul>",
+                                "<li>B11</li>",
+                            "</ul>",
+                        "</li>",
+                        "<li>C1",
+                            "<ul>",
+                                "<li>C11</li>",
+                            "</ul>",
+                        "</li>",
+                    "</ul>",
+                "</li>",
+            "</ul>"
+        ]
+
+        XCTAssertEqual(html, expectedComponents.joined())
+    }
+
     func testUnorderedListWithInvalidMarker() {
         let html = MarkdownParser().html(from: """
         - One
@@ -148,6 +191,7 @@ extension ListTests {
             ("testMixedList", testMixedList),
             ("testUnorderedListWithMultiLineItem", testUnorderedListWithMultiLineItem),
             ("testUnorderedListWithNestedList", testUnorderedListWithNestedList),
+            ("testUnorderedListWithFourLevelsNestedList", testUnorderedListWithFourLevelsNestedList),
             ("testUnorderedListWithInvalidMarker", testUnorderedListWithInvalidMarker)
         ]
     }

--- a/Tests/InkTests/ListTests.swift
+++ b/Tests/InkTests/ListTests.swift
@@ -236,9 +236,9 @@ final class ListTests: XCTestCase {
                     - A111
                 - A12
                     - A121
-            - B1
-                - B11
-                    - B111
+            - A2
+                - A21
+                    - A211
         """)
 
         let expectedComponents: [String] = [
@@ -259,17 +259,59 @@ final class ListTests: XCTestCase {
                                 "</li>",
                             "</ul>",
                         "</li>",
-                        "<li>B1",
+                        "<li>A2",
                             "<ul>",
-                                "<li>B11",
+                                "<li>A21",
                                     "<ul>",
-                                        "<li>B111</li>",
+                                        "<li>A211</li>",
                                     "</ul>",
                                 "</li>",
                             "</ul>",
                         "</li>",
                     "</ul>",
                 "</li>",
+            "</ul>"
+        ]
+
+        XCTAssertEqual(html, expectedComponents.joined())
+    }
+
+    func testUnorderedListWithDoubleSymmetricGrowNestedList() {
+        let html = MarkdownParser().html(from: """
+        - A
+            - A1
+                - A11
+                    - A111
+                - A12
+                    - A121
+                - A13
+            - A2
+        - B
+        """)
+
+        let expectedComponents: [String] = [
+            "<ul>",
+                "<li>A",
+                    "<ul>",
+                        "<li>A1",
+                            "<ul>",
+                                "<li>A11",
+                                    "<ul>",
+                                        "<li>A111</li>",
+                                    "</ul>",
+                                "</li>",
+                                "<li>A12",
+                                    "<ul>",
+                                        "<li>A121</li>",
+                                    "</ul>",
+                                "</li>",
+                                "<li>A13</li>",
+                            "</ul>",
+                        "</li>",
+                        "<li>A2</li>",
+                    "</ul>",
+                "</li>",
+                "<li>B</li>",
             "</ul>"
         ]
 
@@ -304,6 +346,7 @@ extension ListTests {
             ("testUnorderedListWithNestedListWithTwoLevelsGap", testUnorderedListWithNestedListWithTwoLevelsGap),
             ("testUnorderedListWithFourLevelsNestedList", testUnorderedListWithFourLevelsNestedList),
             ("testUnorderedListWithDoubleGrowNestedList", testUnorderedListWithDoubleGrowNestedList),
+            ("testUnorderedListWithDoubleSymmetricGrowNestedList", testUnorderedListWithDoubleSymmetricGrowNestedList),
             ("testUnorderedListWithInvalidMarker", testUnorderedListWithInvalidMarker)
         ]
     }

--- a/Tests/InkTests/ListTests.swift
+++ b/Tests/InkTests/ListTests.swift
@@ -228,7 +228,7 @@ final class ListTests: XCTestCase {
         XCTAssertEqual(html, expectedComponents.joined())
     }
 
-    func testUnorderedListWithDoubleGrowNestedList() {
+    func testUnorderedListWithTripleGrowNestedList() {
         let html = MarkdownParser().html(from: """
         - A
             - A1
@@ -345,7 +345,7 @@ extension ListTests {
             ("testUnorderedListWithNestedListSnakeCase", testUnorderedListWithNestedListSnakeCase),
             ("testUnorderedListWithNestedListWithTwoLevelsGap", testUnorderedListWithNestedListWithTwoLevelsGap),
             ("testUnorderedListWithFourLevelsNestedList", testUnorderedListWithFourLevelsNestedList),
-            ("testUnorderedListWithDoubleGrowNestedList", testUnorderedListWithDoubleGrowNestedList),
+            ("testUnorderedListWithTripleGrowNestedList", testUnorderedListWithTripleGrowNestedList),
             ("testUnorderedListWithDoubleSymmetricGrowNestedList", testUnorderedListWithDoubleSymmetricGrowNestedList),
             ("testUnorderedListWithInvalidMarker", testUnorderedListWithInvalidMarker)
         ]

--- a/Tests/InkTests/ListTests.swift
+++ b/Tests/InkTests/ListTests.swift
@@ -228,6 +228,54 @@ final class ListTests: XCTestCase {
         XCTAssertEqual(html, expectedComponents.joined())
     }
 
+    func testUnorderedListWithDoubleGrowNestedList() {
+        let html = MarkdownParser().html(from: """
+        - A
+            - A1
+                - A11
+                    - A111
+                - A12
+                    - A121
+            - B1
+                - B11
+                    - B111
+        """)
+
+        let expectedComponents: [String] = [
+            "<ul>",
+                "<li>A",
+                    "<ul>",
+                        "<li>A1",
+                            "<ul>",
+                                "<li>A11",
+                                    "<ul>",
+                                        "<li>A111</li>",
+                                    "</ul>",
+                                "</li>",
+                                "<li>A12",
+                                    "<ul>",
+                                        "<li>A121</li>",
+                                    "</ul>",
+                                "</li>",
+                            "</ul>",
+                        "</li>",
+                        "<li>B1",
+                            "<ul>",
+                                "<li>B11",
+                                    "<ul>",
+                                        "<li>B111</li>",
+                                    "</ul>",
+                                "</li>",
+                            "</ul>",
+                        "</li>",
+                    "</ul>",
+                "</li>",
+            "</ul>"
+        ]
+
+        XCTAssertEqual(html, expectedComponents.joined())
+    }
+
     func testUnorderedListWithInvalidMarker() {
         let html = MarkdownParser().html(from: """
         - One
@@ -255,6 +303,7 @@ extension ListTests {
             ("testUnorderedListWithNestedListSnakeCase", testUnorderedListWithNestedListSnakeCase),
             ("testUnorderedListWithNestedListWithTwoLevelsGap", testUnorderedListWithNestedListWithTwoLevelsGap),
             ("testUnorderedListWithFourLevelsNestedList", testUnorderedListWithFourLevelsNestedList),
+            ("testUnorderedListWithDoubleGrowNestedList", testUnorderedListWithDoubleGrowNestedList),
             ("testUnorderedListWithInvalidMarker", testUnorderedListWithInvalidMarker)
         ]
     }

--- a/Tests/InkTests/ListTests.swift
+++ b/Tests/InkTests/ListTests.swift
@@ -152,6 +152,39 @@ final class ListTests: XCTestCase {
         XCTAssertEqual(html, expectedComponents.joined())
     }
 
+    func testUnorderedListWithNestedListSnakeCase() {
+           let html = MarkdownParser().html(from: """
+           - A
+               - A1
+           - B
+               - B1
+           - C
+               - C1
+           """)
+
+           let expectedComponents: [String] = [
+               "<ul>",
+                   "<li>A",
+                       "<ul>",
+                           "<li>A1</li>",
+                       "</ul>",
+                   "</li>",
+                   "<li>B",
+                       "<ul>",
+                           "<li>B1</li>",
+                       "</ul>",
+                   "</li>",
+                   "<li>C",
+                       "<ul>",
+                           "<li>C1</li>",
+                       "</ul>",
+                   "</li>",
+               "</ul>"
+           ]
+
+           XCTAssertEqual(html, expectedComponents.joined())
+       }
+
     func testUnorderedListWithFourLevelsNestedList() {
         let html = MarkdownParser().html(from: """
         - A
@@ -219,6 +252,7 @@ extension ListTests {
             ("testMixedList", testMixedList),
             ("testUnorderedListWithMultiLineItem", testUnorderedListWithMultiLineItem),
             ("testUnorderedListWithNestedList", testUnorderedListWithNestedList),
+            ("testUnorderedListWithNestedListSnakeCase", testUnorderedListWithNestedListSnakeCase),
             ("testUnorderedListWithNestedListWithTwoLevelsGap", testUnorderedListWithNestedListWithTwoLevelsGap),
             ("testUnorderedListWithFourLevelsNestedList", testUnorderedListWithFourLevelsNestedList),
             ("testUnorderedListWithInvalidMarker", testUnorderedListWithInvalidMarker)

--- a/Tests/InkTests/ListTests.swift
+++ b/Tests/InkTests/ListTests.swift
@@ -124,6 +124,34 @@ final class ListTests: XCTestCase {
         XCTAssertEqual(html, expectedComponents.joined())
     }
 
+    func testUnorderedListWithNestedListWithTwoLevelsGap() {
+        let html = MarkdownParser().html(from: """
+        - A
+        - B
+            - B1
+                - B11
+        - C
+        """)
+
+        let expectedComponents: [String] = [
+            "<ul>",
+                "<li>A</li>",
+                "<li>B",
+                    "<ul>",
+                        "<li>B1",
+                            "<ul>",
+                                "<li>B11</li>",
+                            "</ul>",
+                        "</li>",
+                    "</ul>",
+                "</li>",
+                "<li>C</li>",
+            "</ul>"
+        ]
+
+        XCTAssertEqual(html, expectedComponents.joined())
+    }
+
     func testUnorderedListWithFourLevelsNestedList() {
         let html = MarkdownParser().html(from: """
         - A
@@ -191,6 +219,7 @@ extension ListTests {
             ("testMixedList", testMixedList),
             ("testUnorderedListWithMultiLineItem", testUnorderedListWithMultiLineItem),
             ("testUnorderedListWithNestedList", testUnorderedListWithNestedList),
+            ("testUnorderedListWithNestedListWithTwoLevelsGap", testUnorderedListWithNestedListWithTwoLevelsGap),
             ("testUnorderedListWithFourLevelsNestedList", testUnorderedListWithFourLevelsNestedList),
             ("testUnorderedListWithInvalidMarker", testUnorderedListWithInvalidMarker)
         ]


### PR DESCRIPTION
# Challenge

The current list parsing works correctly only when there's just one or two depth levels.
<details>
<summary>Examples</summary>

One level depth:
```
- a
- b
- c
```

Two levels depth:
```
- a
  - a1
  - a2
- b
  - b1
  - b2
```
</details>

However, as soon as there are three levels or more, some issues will appear.

Example: 

The following...
```
- a
- b
  - b1
    - b11
- c
```
...will be parsed as:
```
- a
- b
  - b1
    - b11
  - c
```
(note how `c` is nested instead of being in the root).

# Reason

The issue raises when there are multiple depth levels because of the way the current list parsing works:
when a new element or nested list is found, we parse that and then start the (`while !reader.didReachEnd`) loop again.

In the example above, this means that after parsing the nested list with `b11`, the parsing of the nested list containing `b1` and `b11` continues (despite the fact that no other elements are in that list), and, since we found ourselves in a new loop, we now find `c`, which is incorrectly inserted in the nested list, resulting in the error shown above.

# Solution

In order to address all of the above, after encountering a new nested list or element and before starting a new loop, the parser needs to do some foresight and check if the upcoming element will be part of the current (nested) list or not. 
In order to do that, whitespaces needs to be preserved in some cases.

# Final Comment

I've added multiple tests (some of which would have failed previously) that cover different patterns, however the names are really terrible and I very welcome any naming suggestions.