### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,14 @@ Ink is distributed using the [Swift Package Manager](https://swift.org/package-m
 let package = Package(
     ...
     dependencies: [
-        .package(url: "https://github.com/johnsundell/ink.git", from: "0.1.0")
+        .package(url: "https://github.com/johnsundell/Ink.git", from: "0.5.0")
     ],
     ...
+    targets: [
+        .target(name: "...", dependencies: [
+            .product(name: "Ink", package: "Ink")
+        ]),
+    ]
 )
 ```
 


### PR DESCRIPTION
Change ink.git to Ink.git.
If specify url to "https://github.com/johnsundell/ink.git", package manager will output "product dependency 'Ink' in package 'ink' not found".