### PR TITLE
Add equation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Ink supports the following Markdown features:
 | Row 1  | Cell 1   |
 | Row 2  | Cell 2   |
 ```
+- Inline equations can be created by enclosing the equation with dollar signs, like `$f(\mathbf{r},t)$`. Display mode equations can be created by enclosing the equation with two dollar signs, like `$$\braket{\psi\vert\psi}$$`. Note that Ink does not render math equations. You need another library for that, like [KaTeX](https://katex.org) or [MathJax](https://www.mathjax.org).
 
 Please note that, being a very young implementation, Ink does not fully support all Markdown specs, such as [CommonMark](https://commonmark.org). Ink definitely aims to cover as much ground as possible, and to include support for the most commonly used Markdown features, but if complete CommonMark compatibility is what you’re looking for — then you might want to check out tools like [CMark](https://github.com/commonmark/cmark).
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ Ink supports the following Markdown features:
 | Row 1  | Cell 1   |
 | Row 2  | Cell 2   |
 ```
-- Inline equations can be created by enclosing the equation with dollar signs, like `$f(\mathbf{r},t)$`. Display mode equations can be created by enclosing the equation with two dollar signs, like `$$\braket{\psi\vert\psi}$$`. Note that Ink does not render math equations. You need another library for that, like [KaTeX](https://katex.org) or [MathJax](https://www.mathjax.org).
+- LaTeX like equation support. As dollar signs can be found quite commonly on articles (and the slash character is already the escape character), TeX-like equation input is not supported. Note that Ink does _not_ render math equations. You need another library for that, like [KaTeX](https://katex.org) or [MathJax](https://www.mathjax.org). There are two equation modes:
+  1. Inline mode equations: `\(x^2 + 5\)`
+  2. Display mode equations:  `\[z^2 + 5\]`
 
 Please note that, being a very young implementation, Ink does not fully support all Markdown specs, such as [CommonMark](https://commonmark.org). Ink definitely aims to cover as much ground as possible, and to include support for the most commonly used Markdown features, but if complete CommonMark compatibility is what you’re looking for — then you might want to check out tools like [CMark](https://github.com/commonmark/cmark).
 

--- a/Sources/Ink/API/Modifier.swift
+++ b/Sources/Ink/API/Modifier.swift
@@ -53,5 +53,6 @@ public extension Modifier {
         case lists
         case paragraphs
         case tables
+        case math
     }
 }

--- a/Sources/Ink/Internal/FormattedText.swift
+++ b/Sources/Ink/Internal/FormattedText.swift
@@ -334,7 +334,11 @@ private extension FormattedText {
             case "[": return Link.self
             case "!": return Image.self
             case "<": return HTML.self
-            case "$": return Math.self
+            case "\\":
+                if ["[","("].contains(reader.nextCharacter) {
+                    return Math.self
+                }
+                fallthrough
             default: return nil
             }
         }

--- a/Sources/Ink/Internal/FormattedText.swift
+++ b/Sources/Ink/Internal/FormattedText.swift
@@ -334,6 +334,7 @@ private extension FormattedText {
             case "[": return Link.self
             case "!": return Image.self
             case "<": return HTML.self
+            case "$": return Math.self
             default: return nil
             }
         }

--- a/Sources/Ink/Internal/Math.swift
+++ b/Sources/Ink/Internal/Math.swift
@@ -11,22 +11,34 @@ internal struct Math: Fragment {
     private var tex: String
     
     static func read(using reader: inout Reader) throws -> Math {
-        let startingDollarCount = reader.readCount(of: "$")
-        let displayMode = startingDollarCount > 1 ? true : false
-        
+        reader.advanceIndex()
+        let displayMode: Bool
+        let closingCharacter: Character
+        if reader.currentCharacter == "[" {
+            displayMode = true
+            closingCharacter = "]"
+        } else {
+            displayMode = false
+            closingCharacter = ")"
+        }
+        reader.advanceIndex()
         var tex = ""
         
         while !reader.didReachEnd {
             switch reader.currentCharacter {
             case \.isNewline :
                 throw Reader.Error()
-            case "$":
-                if displayMode {
-                    reader.advanceIndex(by: 2)
-                } else {
-                    reader.advanceIndex()
+            case "\\" :
+                guard let nextCharacter = reader.nextCharacter else {
+                    throw Reader.Error()
                 }
-                return Math(displayMode: displayMode, tex: tex)
+                
+                if nextCharacter == closingCharacter {
+                    reader.advanceIndex(by: 2)
+                    return Math(displayMode: displayMode, tex: tex)
+                }
+                
+                fallthrough
             default:
                 if let escaped = reader.currentCharacter.escaped {
                     tex.append(escaped)

--- a/Sources/Ink/Internal/Math.swift
+++ b/Sources/Ink/Internal/Math.swift
@@ -1,0 +1,53 @@
+/**
+*  Ink
+*  Copyright (c) John Sundell 2019
+*  MIT license, see LICENSE file for details
+*/
+
+internal struct Math: Fragment {
+    var modifierTarget: Modifier.Target { .math }
+    
+    private var displayMode: Bool
+    private var tex: String
+    
+    static func read(using reader: inout Reader) throws -> Math {
+        let startingDollarCount = reader.readCount(of: "$")
+        let displayMode = startingDollarCount > 1 ? true : false
+        
+        var tex = ""
+        
+        while !reader.didReachEnd {
+            switch reader.currentCharacter {
+            case \.isNewline :
+                throw Reader.Error()
+            case "$":
+                if displayMode {
+                    reader.advanceIndex(by: 2)
+                } else {
+                    reader.advanceIndex()
+                }
+                return Math(displayMode: displayMode, tex: tex)
+            default:
+                if let escaped = reader.currentCharacter.escaped {
+                    tex.append(escaped)
+                } else {
+                    tex.append(reader.currentCharacter)
+                }
+                reader.advanceIndex()
+            }
+        }
+        throw Reader.Error()
+    }
+    
+    func html(usingURLs urls: NamedURLCollection,
+              modifiers: ModifierCollection) -> String {
+        let modeString = displayMode ? "display" : "inline"
+        return "<span class=\"math \(modeString)\">\(tex)</span>"
+    }
+    
+    func plainText() -> String {
+        tex
+        
+    }
+}
+

--- a/Tests/InkTests/MathTests.swift
+++ b/Tests/InkTests/MathTests.swift
@@ -9,21 +9,27 @@ import Ink
 
 final class MathTests: XCTestCase {
     func testInlineMath() {
-        let html = MarkdownParser().html(from: "$Hello \\Latex$")
+        let html = MarkdownParser().html(from: "\\(Hello \\Latex\\)")
         XCTAssertEqual(html, "<p><span class=\"math inline\">Hello \\Latex</span></p>")
     }
     
     func testDisplayMath() {
-        let html = MarkdownParser().html(from: "$$Hello \\Latex$$")
+        let html = MarkdownParser().html(from: "\\[Hello \\Latex\\]")
         XCTAssertEqual(html, "<p><span class=\"math display\">Hello \\Latex</span></p>")
     }
-
+    
+    func testMathWithEscape() {
+        let html = MarkdownParser().html(from: "Asterix \\* and \\(Hello \\Latex\\)")
+        XCTAssertEqual(html, "<p>Asterix * and <span class=\"math inline\">Hello \\Latex</span></p>")
+    }
 }
 
 extension MathTests {
     static var allTests: Linux.TestList<MathTests> {
         return [
             ("testInlineMath", testInlineMath),
+            ("testDisplayMath", testDisplayMath),
+            ("testMathWithEscape", testMathWithEscape),
         ]
     }
 }

--- a/Tests/InkTests/MathTests.swift
+++ b/Tests/InkTests/MathTests.swift
@@ -1,0 +1,29 @@
+/**
+*  Ink
+*  Copyright (c) John Sundell 2019
+*  MIT license, see LICENSE file for details
+*/
+
+import XCTest
+import Ink
+
+final class MathTests: XCTestCase {
+    func testInlineMath() {
+        let html = MarkdownParser().html(from: "$Hello \\Latex$")
+        XCTAssertEqual(html, "<p><span class=\"math inline\">Hello \\Latex</span></p>")
+    }
+    
+    func testDisplayMath() {
+        let html = MarkdownParser().html(from: "$$Hello \\Latex$$")
+        XCTAssertEqual(html, "<p><span class=\"math display\">Hello \\Latex</span></p>")
+    }
+
+}
+
+extension MathTests {
+    static var allTests: Linux.TestList<MathTests> {
+        return [
+            ("testInlineMath", testInlineMath),
+        ]
+    }
+}

--- a/Tests/InkTests/XCTestManifests.swift
+++ b/Tests/InkTests/XCTestManifests.swift
@@ -18,6 +18,7 @@ public func allTests() -> [Linux.TestCase] {
         Linux.makeTestCase(using: MarkdownTests.allTests),
         Linux.makeTestCase(using: ModifierTests.allTests),
         Linux.makeTestCase(using: TableTests.allTests),
-        Linux.makeTestCase(using: TextFormattingTests.allTests)
+        Linux.makeTestCase(using: TextFormattingTests.allTests),
+        Linux.makeTestCase(using: MathTests.allTests)
     ]
 }


### PR DESCRIPTION
This PR adds support for equation input in `FormattedText` structs. Equation syntax is similar to Latex, i.e. `\( ... \)` for inline equations, `\[ ... \]` for display mode equations. Since dollar sign is commonly used ,I decided against Tex syntax. This can be changed of course. This PR itself does not do much by itself; it just wraps equations in a span tag. Still, this can come in handy when using a third party framework like KaTeX to render the equation, possibly as a Publish plugin. Finally, I wrote a few tests but I am not sure if they cover every edge case. It would be nice to have more tests.

