### PR TITLE
Support for Swift 5.3 on Linux

### DIFF
--- a/Sources/Ink/API/MarkdownParser.swift
+++ b/Sources/Ink/API/MarkdownParser.swift
@@ -67,7 +67,9 @@ public struct MarkdownParser {
                 let type = fragmentType(for: reader.currentCharacter,
                                         nextCharacter: reader.nextCharacter)
 
-                #if swift(>=5.3)
+                #if swift(>=5.4)
+                #warning("review compiler crash work-around below")
+                #elseif swift(>=5.3)
                 // inline function call to work around https://bugs.swift.org/browse/SR-13645
                 let fragment: ParsedFragment = try {
                     let startIndex = reader.currentIndex

--- a/Sources/Ink/API/MarkdownParser.swift
+++ b/Sources/Ink/API/MarkdownParser.swift
@@ -69,7 +69,7 @@ public struct MarkdownParser {
 
                 #if swift(>=5.4)
                 #warning("review compiler crash work-around below")
-                #elseif swift(>=5.3)
+                #elseif swift(>=5.3) && os(Linux)
                 // inline function call to work around https://bugs.swift.org/browse/SR-13645
                 let fragment: ParsedFragment = try {
                     let startIndex = reader.currentIndex

--- a/Sources/Ink/API/MarkdownParser.swift
+++ b/Sources/Ink/API/MarkdownParser.swift
@@ -67,7 +67,17 @@ public struct MarkdownParser {
                 let type = fragmentType(for: reader.currentCharacter,
                                         nextCharacter: reader.nextCharacter)
 
+                #if swift(>=5.3)
+                // inline function call to work around https://bugs.swift.org/browse/SR-13645
+                let fragment: ParsedFragment = try {
+                    let startIndex = reader.currentIndex
+                    let fragment = try type.readOrRewind(using: &reader)
+                    let rawString = reader.characters(in: startIndex..<reader.currentIndex)
+                    return ParsedFragment(fragment: fragment, rawString: rawString)
+                }()
+                #else
                 let fragment = try makeFragment(using: type.readOrRewind, reader: &reader)
+                #endif
                 fragments.append(fragment)
 
                 if titleHeading == nil, let heading = fragment.fragment as? Heading {


### PR DESCRIPTION
This adds a workaround for a compiler crash when compiling with Swift 5.3 on Linux: https://bugs.swift.org/browse/SR-13645

Tests pass on Linux:

```
❯ docker run --rm -v "$PWD":/host -w /host swift:5.3 swift test
[1/16] Compiling InkTests XCTestManifests.swift
[2/16] Compiling InkTests TableTests.swift
[3/16] Compiling InkTests ImageTests.swift
[4/16] Compiling InkTests LinkTests.swift
[5/16] Compiling InkTests TextFormattingTests.swift
[6/16] Compiling InkTests HeadingTests.swift
[7/16] Compiling InkTests HorizontalLineTests.swift
[8/16] Compiling InkTests LinuxCompatibility.swift
[9/16] Compiling InkTests ListTests.swift
[10/16] Compiling InkTests MarkdownTests.swift
[11/16] Compiling InkTests ModifierTests.swift
[12/16] Compiling InkTests CodeTests.swift
[13/16] Compiling InkTests HTMLTests.swift
[14/17] Merging module InkTests
[15/18] Wrapping AST for InkTests for debugging
[16/18] Compiling InkPackageTests LinuxMain.swift
[17/19] Merging module InkPackageTests
[18/19] Wrapping AST for InkPackageTests for debugging
[19/19] Linking InkPackageTests.xctest
Test Suite 'All tests' started at 2020-10-06 06:05:43.251
Test Suite 'debug.xctest' started at 2020-10-06 06:05:43.272
Test Suite 'CodeTests' started at 2020-10-06 06:05:43.272
Test Case 'CodeTests.testInlineCode' started at 2020-10-06 06:05:43.272
Test Case 'CodeTests.testInlineCode' passed (0.0 seconds)
Test Case 'CodeTests.testCodeBlockWithJustBackticks' started at 2020-10-06 06:05:43.273
Test Case 'CodeTests.testCodeBlockWithJustBackticks' passed (0.0 seconds)
Test Case 'CodeTests.testCodeBlockWithBackticksAndLabel' started at 2020-10-06 06:05:43.273
Test Case 'CodeTests.testCodeBlockWithBackticksAndLabel' passed (0.0 seconds)
Test Case 'CodeTests.testCodeBlockWithBackticksAndLabelNeedingTrimming' started at 2020-10-06 06:05:43.273
Test Case 'CodeTests.testCodeBlockWithBackticksAndLabelNeedingTrimming' passed (0.0 seconds)
Test Case 'CodeTests.testCodeBlockManyBackticks' started at 2020-10-06 06:05:43.273
Test Case 'CodeTests.testCodeBlockManyBackticks' passed (0.0 seconds)
Test Case 'CodeTests.testEncodingSpecialCharactersWithinCodeBlock' started at 2020-10-06 06:05:43.273
Test Case 'CodeTests.testEncodingSpecialCharactersWithinCodeBlock' passed (0.0 seconds)
Test Case 'CodeTests.testIgnoringFormattingWithinCodeBlock' started at 2020-10-06 06:05:43.273
Test Case 'CodeTests.testIgnoringFormattingWithinCodeBlock' passed (0.0 seconds)
Test Suite 'CodeTests' passed at 2020-10-06 06:05:43.273
	 Executed 7 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'HeadingTests' started at 2020-10-06 06:05:43.273
Test Case 'HeadingTests.testHeading' started at 2020-10-06 06:05:43.273
Test Case 'HeadingTests.testHeading' passed (0.0 seconds)
Test Case 'HeadingTests.testHeadingsSeparatedBySingleNewline' started at 2020-10-06 06:05:43.273
Test Case 'HeadingTests.testHeadingsSeparatedBySingleNewline' passed (0.0 seconds)
Test Case 'HeadingTests.testHeadingsWithLeadingNumbers' started at 2020-10-06 06:05:43.273
Test Case 'HeadingTests.testHeadingsWithLeadingNumbers' passed (0.0 seconds)
Test Case 'HeadingTests.testHeadingWithPreviousWhitespace' started at 2020-10-06 06:05:43.274
Test Case 'HeadingTests.testHeadingWithPreviousWhitespace' passed (0.0 seconds)
Test Case 'HeadingTests.testHeadingWithPreviousNewlineAndWhitespace' started at 2020-10-06 06:05:43.274
Test Case 'HeadingTests.testHeadingWithPreviousNewlineAndWhitespace' passed (0.0 seconds)
Test Case 'HeadingTests.testInvalidHeaderLevel' started at 2020-10-06 06:05:43.274
Test Case 'HeadingTests.testInvalidHeaderLevel' passed (0.0 seconds)
Test Case 'HeadingTests.testRemovingTrailingMarkersFromHeading' started at 2020-10-06 06:05:43.274
Test Case 'HeadingTests.testRemovingTrailingMarkersFromHeading' passed (0.0 seconds)
Test Case 'HeadingTests.testHeadingWithOnlyTrailingMarkers' started at 2020-10-06 06:05:43.274
Test Case 'HeadingTests.testHeadingWithOnlyTrailingMarkers' passed (0.0 seconds)
Test Suite 'HeadingTests' passed at 2020-10-06 06:05:43.274
	 Executed 8 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'HorizontalLineTests' started at 2020-10-06 06:05:43.274
Test Case 'HorizontalLineTests.testHorizonalLineWithDashes' started at 2020-10-06 06:05:43.274
Test Case 'HorizontalLineTests.testHorizonalLineWithDashes' passed (0.0 seconds)
Test Case 'HorizontalLineTests.testHorizontalLineWithDashesAtTheStartOfString' started at 2020-10-06 06:05:43.274
Test Case 'HorizontalLineTests.testHorizontalLineWithDashesAtTheStartOfString' passed (0.0 seconds)
Test Case 'HorizontalLineTests.testHorizontalLineWithAsterisks' started at 2020-10-06 06:05:43.274
Test Case 'HorizontalLineTests.testHorizontalLineWithAsterisks' passed (0.0 seconds)
Test Suite 'HorizontalLineTests' passed at 2020-10-06 06:05:43.274
	 Executed 3 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
Test Suite 'HTMLTests' started at 2020-10-06 06:05:43.274
Test Case 'HTMLTests.testTopLevelHTML' started at 2020-10-06 06:05:43.274
Test Case 'HTMLTests.testTopLevelHTML' passed (0.0 seconds)
Test Case 'HTMLTests.testNestedTopLevelHTML' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testNestedTopLevelHTML' passed (0.0 seconds)
Test Case 'HTMLTests.testTopLevelHTMLWithPreviousNewline' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testTopLevelHTMLWithPreviousNewline' passed (0.0 seconds)
Test Case 'HTMLTests.testIgnoringFormattingWithinTopLevelHTML' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testIgnoringFormattingWithinTopLevelHTML' passed (0.0 seconds)
Test Case 'HTMLTests.testIgnoringTextFormattingWithinInlineHTML' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testIgnoringTextFormattingWithinInlineHTML' passed (0.0 seconds)
Test Case 'HTMLTests.testIgnoringListsWithinInlineHTML' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testIgnoringListsWithinInlineHTML' passed (0.0 seconds)
Test Case 'HTMLTests.testInlineParagraphTagEndingCurrentParagraph' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testInlineParagraphTagEndingCurrentParagraph' passed (0.0 seconds)
Test Case 'HTMLTests.testTopLevelSelfClosingHTMLElement' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testTopLevelSelfClosingHTMLElement' passed (0.0 seconds)
Test Case 'HTMLTests.testInlineSelfClosingHTMLElement' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testInlineSelfClosingHTMLElement' passed (0.0 seconds)
Test Case 'HTMLTests.testTopLevelHTMLLineBreak' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testTopLevelHTMLLineBreak' passed (0.0 seconds)
Test Case 'HTMLTests.testHTMLComment' started at 2020-10-06 06:05:43.275
Test Case 'HTMLTests.testHTMLComment' passed (0.0 seconds)
Test Case 'HTMLTests.testHTMLEntities' started at 2020-10-06 06:05:43.276
Test Case 'HTMLTests.testHTMLEntities' passed (0.0 seconds)
Test Suite 'HTMLTests' passed at 2020-10-06 06:05:43.276
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ImageTests' started at 2020-10-06 06:05:43.276
Test Case 'ImageTests.testImageWithURL' started at 2020-10-06 06:05:43.276
Test Case 'ImageTests.testImageWithURL' passed (0.0 seconds)
Test Case 'ImageTests.testImageWithReference' started at 2020-10-06 06:05:43.276
Test Case 'ImageTests.testImageWithReference' passed (0.0 seconds)
Test Case 'ImageTests.testImageWithURLAndAltText' started at 2020-10-06 06:05:43.276
Test Case 'ImageTests.testImageWithURLAndAltText' passed (0.0 seconds)
Test Case 'ImageTests.testImageWithReferenceAndAltText' started at 2020-10-06 06:05:43.276
Test Case 'ImageTests.testImageWithReferenceAndAltText' passed (0.0 seconds)
Test Case 'ImageTests.testImageWithinParagraph' started at 2020-10-06 06:05:43.276
Test Case 'ImageTests.testImageWithinParagraph' passed (0.0 seconds)
Test Suite 'ImageTests' passed at 2020-10-06 06:05:43.276
	 Executed 5 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
Test Suite 'LinkTests' started at 2020-10-06 06:05:43.276
Test Case 'LinkTests.testLinkWithURL' started at 2020-10-06 06:05:43.276
Test Case 'LinkTests.testLinkWithURL' passed (0.0 seconds)
Test Case 'LinkTests.testLinkWithReference' started at 2020-10-06 06:05:43.276
Test Case 'LinkTests.testLinkWithReference' passed (0.0 seconds)
Test Case 'LinkTests.testCaseMismatchedLinkWithReference' started at 2020-10-06 06:05:43.276
Test Case 'LinkTests.testCaseMismatchedLinkWithReference' passed (0.002 seconds)
Test Case 'LinkTests.testNumericLinkWithReference' started at 2020-10-06 06:05:43.278
Test Case 'LinkTests.testNumericLinkWithReference' passed (0.0 seconds)
Test Case 'LinkTests.testBoldLinkWithInternalMarkers' started at 2020-10-06 06:05:43.279
Test Case 'LinkTests.testBoldLinkWithInternalMarkers' passed (0.0 seconds)
Test Case 'LinkTests.testBoldLinkWithExternalMarkers' started at 2020-10-06 06:05:43.279
Test Case 'LinkTests.testBoldLinkWithExternalMarkers' passed (0.0 seconds)
Test Case 'LinkTests.testLinkWithUnderscores' started at 2020-10-06 06:05:43.279
Test Case 'LinkTests.testLinkWithUnderscores' passed (0.0 seconds)
Test Case 'LinkTests.testUnterminatedLink' started at 2020-10-06 06:05:43.279
Test Case 'LinkTests.testUnterminatedLink' passed (0.0 seconds)
Test Case 'LinkTests.testLinkWithEscapedSquareBrackets' started at 2020-10-06 06:05:43.279
Test Case 'LinkTests.testLinkWithEscapedSquareBrackets' passed (0.0 seconds)
Test Suite 'LinkTests' passed at 2020-10-06 06:05:43.279
	 Executed 9 tests, with 0 failures (0 unexpected) in 0.003 (0.003) seconds
Test Suite 'ListTests' started at 2020-10-06 06:05:43.279
Test Case 'ListTests.testOrderedList' started at 2020-10-06 06:05:43.279
Test Case 'ListTests.testOrderedList' passed (0.0 seconds)
Test Case 'ListTests.test10DigitOrderedList' started at 2020-10-06 06:05:43.280
Test Case 'ListTests.test10DigitOrderedList' passed (0.0 seconds)
Test Case 'ListTests.testOrderedListParentheses' started at 2020-10-06 06:05:43.280
Test Case 'ListTests.testOrderedListParentheses' passed (0.0 seconds)
Test Case 'ListTests.testOrderedListWithoutIncrementedNumbers' started at 2020-10-06 06:05:43.280
Test Case 'ListTests.testOrderedListWithoutIncrementedNumbers' passed (0.0 seconds)
Test Case 'ListTests.testOrderedListWithInvalidNumbers' started at 2020-10-06 06:05:43.280
Test Case 'ListTests.testOrderedListWithInvalidNumbers' passed (0.0 seconds)
Test Case 'ListTests.testUnorderedList' started at 2020-10-06 06:05:43.280
Test Case 'ListTests.testUnorderedList' passed (0.0 seconds)
Test Case 'ListTests.testMixedUnorderedList' started at 2020-10-06 06:05:43.280
Test Case 'ListTests.testMixedUnorderedList' passed (0.0 seconds)
Test Case 'ListTests.testMixedList' started at 2020-10-06 06:05:43.280
Test Case 'ListTests.testMixedList' passed (0.0 seconds)
Test Case 'ListTests.testUnorderedListWithMultiLineItem' started at 2020-10-06 06:05:43.280
Test Case 'ListTests.testUnorderedListWithMultiLineItem' passed (0.0 seconds)
Test Case 'ListTests.testUnorderedListWithNestedList' started at 2020-10-06 06:05:43.280
Test Case 'ListTests.testUnorderedListWithNestedList' passed (0.0 seconds)
Test Case 'ListTests.testUnorderedListWithInvalidMarker' started at 2020-10-06 06:05:43.281
Test Case 'ListTests.testUnorderedListWithInvalidMarker' passed (0.0 seconds)
Test Suite 'ListTests' passed at 2020-10-06 06:05:43.281
	 Executed 11 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'MarkdownTests' started at 2020-10-06 06:05:43.281
Test Case 'MarkdownTests.testParsingMetadata' started at 2020-10-06 06:05:43.281
Test Case 'MarkdownTests.testParsingMetadata' passed (0.0 seconds)
Test Case 'MarkdownTests.testDiscardingEmptyMetadataValues' started at 2020-10-06 06:05:43.281
Test Case 'MarkdownTests.testDiscardingEmptyMetadataValues' passed (0.0 seconds)
Test Case 'MarkdownTests.testMergingOrphanMetadataValueIntoPreviousOne' started at 2020-10-06 06:05:43.281
Test Case 'MarkdownTests.testMergingOrphanMetadataValueIntoPreviousOne' passed (0.0 seconds)
Test Case 'MarkdownTests.testMissingMetadata' started at 2020-10-06 06:05:43.281
Test Case 'MarkdownTests.testMissingMetadata' passed (0.0 seconds)
Test Case 'MarkdownTests.testMetadataModifiers' started at 2020-10-06 06:05:43.281
Test Case 'MarkdownTests.testMetadataModifiers' passed (0.0 seconds)
Test Case 'MarkdownTests.testPlainTextTitle' started at 2020-10-06 06:05:43.281
Test Case 'MarkdownTests.testPlainTextTitle' passed (0.0 seconds)
Test Case 'MarkdownTests.testRemovingTrailingMarkersFromTitle' started at 2020-10-06 06:05:43.281
Test Case 'MarkdownTests.testRemovingTrailingMarkersFromTitle' passed (0.0 seconds)
Test Case 'MarkdownTests.testConvertingFormattedTitleTextToPlainText' started at 2020-10-06 06:05:43.281
Test Case 'MarkdownTests.testConvertingFormattedTitleTextToPlainText' passed (0.0 seconds)
Test Case 'MarkdownTests.testTreatingFirstHeadingAsTitle' started at 2020-10-06 06:05:43.282
Test Case 'MarkdownTests.testTreatingFirstHeadingAsTitle' passed (0.0 seconds)
Test Case 'MarkdownTests.testOverridingTitle' started at 2020-10-06 06:05:43.282
Test Case 'MarkdownTests.testOverridingTitle' passed (0.0 seconds)
Test Suite 'MarkdownTests' passed at 2020-10-06 06:05:43.282
	 Executed 10 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds
Test Suite 'ModifierTests' started at 2020-10-06 06:05:43.282
Test Case 'ModifierTests.testModifierInput' started at 2020-10-06 06:05:43.282
Test Case 'ModifierTests.testModifierInput' passed (0.0 seconds)
Test Case 'ModifierTests.testInitializingParserWithModifiers' started at 2020-10-06 06:05:43.282
Test Case 'ModifierTests.testInitializingParserWithModifiers' passed (0.0 seconds)
Test Case 'ModifierTests.testAddingModifiers' started at 2020-10-06 06:05:43.282
Test Case 'ModifierTests.testAddingModifiers' passed (0.0 seconds)
Test Case 'ModifierTests.testMultipleModifiersForSameTarget' started at 2020-10-06 06:05:43.282
Test Case 'ModifierTests.testMultipleModifiersForSameTarget' passed (0.0 seconds)
Test Suite 'ModifierTests' passed at 2020-10-06 06:05:43.282
	 Executed 4 tests, with 0 failures (0 unexpected) in 0.0 (0.0) seconds
Test Suite 'TableTests' started at 2020-10-06 06:05:43.282
Test Case 'TableTests.testTableWithoutHeader' started at 2020-10-06 06:05:43.282
Test Case 'TableTests.testTableWithoutHeader' passed (0.0 seconds)
Test Case 'TableTests.testTableWithHeader' started at 2020-10-06 06:05:43.282
Test Case 'TableTests.testTableWithHeader' passed (0.0 seconds)
Test Case 'TableTests.testTableWithUnalignedColumns' started at 2020-10-06 06:05:43.283
Test Case 'TableTests.testTableWithUnalignedColumns' passed (0.0 seconds)
Test Case 'TableTests.testTableWithOnlyHeader' started at 2020-10-06 06:05:43.283
Test Case 'TableTests.testTableWithOnlyHeader' passed (0.0 seconds)
Test Case 'TableTests.testIncompleteTable' started at 2020-10-06 06:05:43.283
Test Case 'TableTests.testIncompleteTable' passed (0.0 seconds)
Test Case 'TableTests.testInvalidTable' started at 2020-10-06 06:05:43.284
Test Case 'TableTests.testInvalidTable' passed (0.0 seconds)
Test Case 'TableTests.testTableBetweenParagraphs' started at 2020-10-06 06:05:43.284
Test Case 'TableTests.testTableBetweenParagraphs' passed (0.0 seconds)
Test Case 'TableTests.testTableWithUnevenColumns' started at 2020-10-06 06:05:43.284
Test Case 'TableTests.testTableWithUnevenColumns' passed (0.0 seconds)
Test Case 'TableTests.testTableWithInternalMarkdown' started at 2020-10-06 06:05:43.284
Test Case 'TableTests.testTableWithInternalMarkdown' passed (0.0 seconds)
Test Case 'TableTests.testTableWithAlignment' started at 2020-10-06 06:05:43.284
Test Case 'TableTests.testTableWithAlignment' passed (0.0 seconds)
Test Case 'TableTests.testMissingPipeEndsTable' started at 2020-10-06 06:05:43.285
Test Case 'TableTests.testMissingPipeEndsTable' passed (0.0 seconds)
Test Case 'TableTests.testHeaderNotParsedForColumnCountMismatch' started at 2020-10-06 06:05:43.285
Test Case 'TableTests.testHeaderNotParsedForColumnCountMismatch' passed (0.0 seconds)
Test Suite 'TableTests' passed at 2020-10-06 06:05:43.285
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
Test Suite 'TextFormattingTests' started at 2020-10-06 06:05:43.285
Test Case 'TextFormattingTests.testParagraph' started at 2020-10-06 06:05:43.285
Test Case 'TextFormattingTests.testParagraph' passed (0.0 seconds)
Test Case 'TextFormattingTests.testItalicText' started at 2020-10-06 06:05:43.285
Test Case 'TextFormattingTests.testItalicText' passed (0.0 seconds)
Test Case 'TextFormattingTests.testBoldText' started at 2020-10-06 06:05:43.285
Test Case 'TextFormattingTests.testBoldText' passed (0.0 seconds)
Test Case 'TextFormattingTests.testItalicBoldText' started at 2020-10-06 06:05:43.285
Test Case 'TextFormattingTests.testItalicBoldText' passed (0.0 seconds)
Test Case 'TextFormattingTests.testItalicBoldTextWithSeparateStartMarkers' started at 2020-10-06 06:05:43.285
Test Case 'TextFormattingTests.testItalicBoldTextWithSeparateStartMarkers' passed (0.0 seconds)
Test Case 'TextFormattingTests.testItalicTextWithinBoldText' started at 2020-10-06 06:05:43.285
Test Case 'TextFormattingTests.testItalicTextWithinBoldText' passed (0.0 seconds)
Test Case 'TextFormattingTests.testBoldTextWithinItalicText' started at 2020-10-06 06:05:43.285
Test Case 'TextFormattingTests.testBoldTextWithinItalicText' passed (0.0 seconds)
Test Case 'TextFormattingTests.testItalicTextWithExtraLeadingMarkers' started at 2020-10-06 06:05:43.285
Test Case 'TextFormattingTests.testItalicTextWithExtraLeadingMarkers' passed (0.0 seconds)
Test Case 'TextFormattingTests.testBoldTextWithExtraLeadingMarkers' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testBoldTextWithExtraLeadingMarkers' passed (0.0 seconds)
Test Case 'TextFormattingTests.testItalicTextWithExtraTrailingMarkers' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testItalicTextWithExtraTrailingMarkers' passed (0.0 seconds)
Test Case 'TextFormattingTests.testBoldTextWithExtraTrailingMarkers' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testBoldTextWithExtraTrailingMarkers' passed (0.0 seconds)
Test Case 'TextFormattingTests.testItalicBoldTextWithExtraTrailingMarkers' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testItalicBoldTextWithExtraTrailingMarkers' passed (0.0 seconds)
Test Case 'TextFormattingTests.testUnterminatedItalicMarker' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testUnterminatedItalicMarker' passed (0.0 seconds)
Test Case 'TextFormattingTests.testUnterminatedBoldMarker' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testUnterminatedBoldMarker' passed (0.0 seconds)
Test Case 'TextFormattingTests.testUnterminatedItalicBoldMarker' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testUnterminatedItalicBoldMarker' passed (0.0 seconds)
Test Case 'TextFormattingTests.testUnterminatedItalicMarkerWithinBoldText' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testUnterminatedItalicMarkerWithinBoldText' passed (0.0 seconds)
Test Case 'TextFormattingTests.testUnterminatedBoldMarkerWithinItalicText' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testUnterminatedBoldMarkerWithinItalicText' passed (0.0 seconds)
Test Case 'TextFormattingTests.testStrikethroughText' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testStrikethroughText' passed (0.0 seconds)
Test Case 'TextFormattingTests.testSingleTildeWithinStrikethroughText' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testSingleTildeWithinStrikethroughText' passed (0.0 seconds)
Test Case 'TextFormattingTests.testUnterminatedStrikethroughMarker' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testUnterminatedStrikethroughMarker' passed (0.0 seconds)
Test Case 'TextFormattingTests.testEncodingSpecialCharacters' started at 2020-10-06 06:05:43.286
Test Case 'TextFormattingTests.testEncodingSpecialCharacters' passed (0.0 seconds)
Test Case 'TextFormattingTests.testSingleLineBlockquote' started at 2020-10-06 06:05:43.287
Test Case 'TextFormattingTests.testSingleLineBlockquote' passed (0.0 seconds)
Test Case 'TextFormattingTests.testMultiLineBlockquote' started at 2020-10-06 06:05:43.287
Test Case 'TextFormattingTests.testMultiLineBlockquote' passed (0.0 seconds)
Test Case 'TextFormattingTests.testEscapingSymbolsWithBackslash' started at 2020-10-06 06:05:43.287
Test Case 'TextFormattingTests.testEscapingSymbolsWithBackslash' passed (0.0 seconds)
Test Case 'TextFormattingTests.testDoubleSpacedHardLinebreak' started at 2020-10-06 06:05:43.287
Test Case 'TextFormattingTests.testDoubleSpacedHardLinebreak' passed (0.0 seconds)
Test Case 'TextFormattingTests.testEscapedHardLinebreak' started at 2020-10-06 06:05:43.287
Test Case 'TextFormattingTests.testEscapedHardLinebreak' passed (0.0 seconds)
Test Suite 'TextFormattingTests' passed at 2020-10-06 06:05:43.287
	 Executed 26 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds
Test Suite 'debug.xctest' passed at 2020-10-06 06:05:43.287
	 Executed 107 tests, with 0 failures (0 unexpected) in 0.013 (0.013) seconds
Test Suite 'All tests' passed at 2020-10-06 06:05:43.287
	 Executed 107 tests, with 0 failures (0 unexpected) in 0.013 (0.013) seconds
```

I've also tested they pass for Swift 5.2.4/Linux as well as macOS 5.3.