### PR TITLE
Recognize CR-LF pairs as newlines for the purposes of Paragraph separation.

### DIFF
--- a/Sources/Ink/Internal/FormattedText.swift
+++ b/Sources/Ink/Internal/FormattedText.swift
@@ -115,7 +115,7 @@ private extension FormattedText {
                             continue
                         }
 
-                        guard !nextCharacter.isAny(of: ["\n", "#", "<", "`"]) else {
+                        guard !nextCharacter.isAny(of: ["\n", "#", "<", "`", "\r\n"]) else {
                             break
                         }
 

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -13,6 +13,16 @@ final class TextFormattingTests: XCTestCase {
         XCTAssertEqual(html, "<p>Hello, world!</p>")
     }
 
+    func testParagraphs() {
+        let html = MarkdownParser().html(from: "Hello, world!\n\nAgain.")
+        XCTAssertEqual(html, "<p>Hello, world!</p><p>Again.</p>")
+    }
+
+    func testDosParagraphs() {
+        let html = MarkdownParser().html(from: "Hello, world!\r\n\r\nAgain.")
+        XCTAssertEqual(html, "<p>Hello, world!</p><p>Again.</p>")
+    }
+
     func testItalicText() {
         let html = MarkdownParser().html(from: "Hello, *world*!")
         XCTAssertEqual(html, "<p>Hello, <em>world</em>!</p>")
@@ -154,6 +164,8 @@ extension TextFormattingTests {
     static var allTests: Linux.TestList<TextFormattingTests> {
         return [
             ("testParagraph", testParagraph),
+            ("testParagraphs", testParagraphs),
+            ("testDosParagraphs", testDosParagraphs),
             ("testItalicText", testItalicText),
             ("testBoldText", testBoldText),
             ("testItalicBoldText", testItalicBoldText),


### PR DESCRIPTION
Currently if the source text is using DOS style CRLF newlines they will not be recognized as paragraph separators when a blank line is built from them. This is a common occurrence if you wish to accept input from web browsers.

This adds a ridiculously tiny code change to recognize the CRLF newline variant and contains a couple tests for verifying both regular LF-LF and CRLF-CRLF paragraph delimiters.

I didn't find any definitive statement on what Markdown accepts as newlines, but given the generally loose definition it seems reasonable to permit this.