### PR TITLE
Fix formatting of indented lists

### DIFF
--- a/Sources/Ink/Internal/List.swift
+++ b/Sources/Ink/Internal/List.swift
@@ -12,7 +12,15 @@ internal struct List: Fragment {
     private var items = [Item]()
 
     static func read(using reader: inout Reader) throws -> List {
-        try read(using: &reader, indentationLength: 0)
+        // Calculate initial indentation
+        var indentationLength = 0
+        while reader.previousCharacter?.isSameLineWhitespace == true {
+            indentationLength += 1
+            reader.rewindIndex()
+        }
+        reader.advanceIndex(by: indentationLength)
+        
+        return try read(using: &reader, indentationLength: indentationLength)
     }
 
     private static func read(using reader: inout Reader,

--- a/Tests/InkTests/ListTests.swift
+++ b/Tests/InkTests/ListTests.swift
@@ -133,6 +133,25 @@ final class ListTests: XCTestCase {
 
         XCTAssertEqual(html, "<ul><li>One -Two</li><li>Three</li></ul>")
     }
+    
+    func testOrderedIndentedList() {
+        let html = MarkdownParser().html(from: """
+          1. One
+          2. Two
+        """)
+
+        XCTAssertEqual(html, #"<ol><li>One</li><li>Two</li></ol>"#)
+    }
+    
+    func testUnorderedIndentedList() {
+        let html = MarkdownParser().html(from: """
+          - One
+          - Two
+          - Three
+        """)
+
+        XCTAssertEqual(html, "<ul><li>One</li><li>Two</li><li>Three</li></ul>")
+    }
 }
 
 extension ListTests {
@@ -148,7 +167,9 @@ extension ListTests {
             ("testMixedList", testMixedList),
             ("testUnorderedListWithMultiLineItem", testUnorderedListWithMultiLineItem),
             ("testUnorderedListWithNestedList", testUnorderedListWithNestedList),
-            ("testUnorderedListWithInvalidMarker", testUnorderedListWithInvalidMarker)
+            ("testUnorderedListWithInvalidMarker", testUnorderedListWithInvalidMarker),
+            ("testOrderedIndentedList", testUnorderedIndentedList),
+            ("testUnorderedIndentedList", testUnorderedIndentedList),
         ]
     }
 }


### PR DESCRIPTION
When parsing a list which is indented the parser needs to take into account the indentation of the first element otherwise it will it consider subsequent elements to be part of another list internal to the original list ie previously
```
  - first
  - second
  - third
```
produces HTML
```html
<ul><li>One<ul><li>Two</li><li>Three</li></ul></li></ul>
```
With this fix it now produces
```html
<ul><li>One</li><li>Two</li><li>Three</li></ul>
```