### PR TITLE
Fix formatting of lists appearing immediately after a paragraph

### DIFF
--- a/Sources/Ink/Internal/FormattedText.swift
+++ b/Sources/Ink/Internal/FormattedText.swift
@@ -109,13 +109,13 @@ private extension FormattedText {
                             break
                         }
 
-                        guard reader.previousCharacter != "\\" && !(sequentialSpaceCount >= 2) else {
+                        guard reader.previousCharacter != "\\" && sequentialSpaceCount < 2 else {
                             text.components.append(.linebreak)
                             skipCharacter()
                             continue
                         }
 
-                        guard !nextCharacter.isAny(of: ["\n", "#", "<", "`"]) else {
+                        guard !nextCharacter.isAny(of: ["\n", "#", "<", "`", "-"]) else {
                             break
                         }
 

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -137,6 +137,19 @@ final class TextFormattingTests: XCTestCase {
         XCTAssertEqual(html, "<p># Not a title *Not italic*</p>")
     }
 
+
+    func testListAfterFormattedText() {
+        let html = MarkdownParser().html(from: """
+            This is a test
+            - One
+            - Two
+            """)
+
+        XCTAssertEqual(html, """
+            <p>This is a test</p><ul><li>One</li><li>Two</li></ul>
+            """)
+    }
+
     func testDoubleSpacedHardLinebreak() {
         let html = MarkdownParser().html(from: "Line 1  \nLine 2")
 
@@ -177,6 +190,7 @@ extension TextFormattingTests {
             ("testSingleLineBlockquote", testSingleLineBlockquote),
             ("testMultiLineBlockquote", testMultiLineBlockquote),
             ("testEscapingSymbolsWithBackslash", testEscapingSymbolsWithBackslash),
+            ("testListAfterFormattedText", testListAfterFormattedText),
             ("testDoubleSpacedHardLinebreak", testDoubleSpacedHardLinebreak),
             ("testEscapedHardLinebreak", testEscapedHardLinebreak)
         ]


### PR DESCRIPTION
If no space is left between formatted text and a list then the list isn't processed as a list
```
This is a test
- One
- Two
```
Became `<p>This is a test - One - Two</p>`. 
This fix ensures the list is rendered correctly as `<p>This is a test</p><ul><li>One</li><li>Two</li></ul>`.

It is a very simple fix to check for "-" character after a new line along with other special characters.