### PR TITLE
Fix incorrect case in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Ink is distributed using the [Swift Package Manager](https://swift.org/package-m
 let package = Package(
     ...
     dependencies: [
-        .package(url: "https://github.com/johnsundell/ink.git", from: "0.1.0")
+        .package(url: "https://github.com/johnsundell/Ink", from: "0.1.0")
     ],
     ...
 )


### PR DESCRIPTION
Installation instruction referred to 'ink' instead of 'Ink'. Copying that could lead to painful things when trying to build. 😬 