### PR TITLE
Pass plain text to the modifier closure where available

### DIFF
--- a/Sources/Ink/API/Modifier.swift
+++ b/Sources/Ink/API/Modifier.swift
@@ -18,7 +18,7 @@ public struct Modifier {
     /// contains the HTML that was generated for a fragment, and
     /// its raw Markdown representation. Note that for metadata
     /// targets, the two input arguments will be equivalent.
-    public typealias Input = (html: String, markdown: Substring)
+    public typealias Input = (html: String, plainText: String?, markdown: Substring)
     /// The type of closure that Modifiers are based on. Each
     /// modifier is given a set of input, and is expected to return
     /// an HTML string after performing its modifications.

--- a/Sources/Ink/Internal/HTMLConvertible.swift
+++ b/Sources/Ink/Internal/HTMLConvertible.swift
@@ -15,8 +15,13 @@ extension HTMLConvertible where Self: Modifiable {
               applyingModifiers modifiers: ModifierCollection) -> String {
         var html = self.html(usingURLs: urls, modifiers: modifiers)
 
+        var plainText: String? = nil
+        if let plainTextConvertible = self as? PlainTextConvertible {
+          plainText = plainTextConvertible.plainText()
+        }
+
         modifiers.applyModifiers(for: modifierTarget) { modifier in
-            html = modifier.closure((html, rawString))
+            html = modifier.closure((html, plainText, rawString))
         }
 
         return html

--- a/Sources/Ink/Internal/Metadata.swift
+++ b/Sources/Ink/Internal/Metadata.swift
@@ -48,7 +48,7 @@ internal struct Metadata: Readable {
 
         modifiers.applyModifiers(for: .metadataKeys) { modifier in
             for (key, value) in modified.values {
-                let newKey = modifier.closure((key, Substring(key)))
+                let newKey = modifier.closure((key, key, Substring(key)))
                 modified.values[key] = nil
                 modified.values[newKey] = value
             }
@@ -56,7 +56,7 @@ internal struct Metadata: Readable {
 
         modifiers.applyModifiers(for: .metadataValues) { modifier in
             modified.values = modified.values.mapValues { value in
-                modifier.closure((value, Substring(value)))
+                modifier.closure((value, value, Substring(value)))
             }
         }
 

--- a/Tests/InkTests/MarkdownTests.swift
+++ b/Tests/InkTests/MarkdownTests.swift
@@ -69,10 +69,10 @@ final class MarkdownTests: XCTestCase {
 
     func testMetadataModifiers() {
         let parser = MarkdownParser(modifiers: [
-            Modifier(target: .metadataKeys) { key, _ in
+            Modifier(target: .metadataKeys) { key, _, _ in
                 "ModifiedKey-" + key
             },
-            Modifier(target: .metadataValues) { value, _ in
+            Modifier(target: .metadataValues) { value, _, _ in
                 "ModifiedValue-" + value
             }
         ])

--- a/Tests/InkTests/ModifierTests.swift
+++ b/Tests/InkTests/ModifierTests.swift
@@ -10,11 +10,15 @@ import Ink
 final class ModifierTests: XCTestCase {
     func testModifierInput() {
         var allHTML = [String]()
+        var allPlainText = [String]()
         var allMarkdown = [Substring]()
 
         let parser = MarkdownParser(modifiers: [
-            Modifier(target: .paragraphs) { html, markdown in
+            Modifier(target: .paragraphs) { html, plainText, markdown in
                 allHTML.append(html)
+                if let plainText = plainText {
+                  allPlainText.append(plainText)
+                }
                 allMarkdown.append(markdown)
                 return html
             }
@@ -23,6 +27,7 @@ final class ModifierTests: XCTestCase {
         let html = parser.html(from: "One\n\nTwo\n\nThree")
         XCTAssertEqual(html, "<p>One</p><p>Two</p><p>Three</p>")
         XCTAssertEqual(allHTML, ["<p>One</p>", "<p>Two</p>", "<p>Three</p>"])
+        XCTAssertEqual(allPlainText, ["One", "Two", "Three"])
         XCTAssertEqual(allMarkdown, ["One", "Two", "Three"])
     }
 


### PR DESCRIPTION
# Overview
It seems to me like it would be valuable to have the plain text provided as part of the `Modifier`'s closure. Currently the closure is passed the HTML generated by Ink (which is useful if one wants to append a prefix or suffix) and the original markdown (which is useful if one wants to perform a completely custom parsing I guess?).

But you don't get the raw text content from the markdown. I can see this being useful in places where eg you want to generate really specific HTML or (as in my use case) where I want to generate a plain text version of the string to go along with the HTML version (for additional analysis like applying [Hemmingway Editor](http://www.hemingwayapp.com/) style rules to the document).

Given I already have the original markdown I _could_ always parse it again, but that feels like unnecessary work.


# Testing steps
I ran `swift build` from the command line and confirmed the build built correctly using MacOS 11.2 (Big Sur). I also ran `swift test` and confirmed the tests pass.

I amended the `testModifierInput` test to also check that the plain text was generated successfully. 

I have not tested on Linux.

# Considerations
Firstly, the API has now been changed to return an optional String, as not all implementations of `HTMLConvertible` are implementations of `PlainTextConvertible`. (Although in practise I think they all are currently, right?). This is simplified from an API point of view if we instead change the `extension` to:

`extension HTMLConvertible where Self: Modifiable & PlainTextConvertible`, but then you're coupling the `Modifiable` and `PlainTextConvertabile` protocols, which seems undesirable.

This is also a breaking change as existing modifiers will need to be updated to include `plainText` (or `_`) in the closure argument list.
