### PR TITLE
RFC: Output plain text

### DIFF
--- a/Sources/Ink/API/Markdown.swift
+++ b/Sources/Ink/API/Markdown.swift
@@ -15,6 +15,8 @@ public struct Markdown {
     /// The HTML representation of the Markdown, ready to
     /// be rendered in a web browser.
     public var html: String
+    /// The Plain Text representation of the Markdown
+    public var plainText: String
     /// The inferred title of the document, from any top-level
     /// heading found when parsing. If the Markdown text contained
     /// two top-level headings, then this property will contain
@@ -32,9 +34,11 @@ public struct Markdown {
     private var titleStorage = TitleStorage()
 
     internal init(html: String,
+                  plainText: String,
                   titleHeading: Heading?,
                   metadata: [String : String]) {
         self.html = html
+        self.plainText = plainText
         self.titleHeading = titleHeading
         self.metadata = metadata
     }

--- a/Sources/Ink/API/MarkdownParser.swift
+++ b/Sources/Ink/API/MarkdownParser.swift
@@ -36,6 +36,10 @@ public struct MarkdownParser {
         parse(markdown).html
     }
 
+    public func plainText(from markdown: String) -> String {
+        parse(markdown).plainText
+    }
+
     /// Parse a Markdown string into a `Markdown` value, which contains
     /// both the HTML representation of the given string, and also any
     /// metadata values found within it.
@@ -105,8 +109,14 @@ public struct MarkdownParser {
             result.append(html)
         }
 
+        let plainText = fragments.reduce(into: "", { result, wrapper in
+            let plainText = wrapper.fragment.plainText()
+            result.append(plainText)
+        })
+
         return Markdown(
             html: html,
+            plainText: plainText,
             titleHeading: titleHeading,
             metadata: metadata?.values ?? [:]
         )

--- a/Tests/InkTests/CodeTests.swift
+++ b/Tests/InkTests/CodeTests.swift
@@ -9,8 +9,12 @@ import Ink
 
 final class CodeTests: XCTestCase {
     func testInlineCode() {
-        let html = MarkdownParser().html(from: "Hello `inline.code()`")
+        let markdown = "Hello `inline.code()`";
+        let html = MarkdownParser().html(from: markdown)
+        let plainText = MarkdownParser().plainText(from: markdown)
+
         XCTAssertEqual(html, "<p>Hello <code>inline.code()</code></p>")
+        XCTAssertEqual(plainText, "Hello inline.code()")
     }
 
     func testCodeBlockWithJustBackticks() {


### PR DESCRIPTION
# Overview
I'd like to be able to request the output of the Ink parser in a plain text format as well as an HTML format. This PR adds that functionality.

I have only updated a single test so far as a demonstration that it works. I expect this idea will be shot down for performance reasons, so I want to put this out as a litmus test first. I can update all the tests if people are happy with the concept :)