### PR TITLE
Disable Swift 5.3 workaround for 5.4 and higher

### DIFF
--- a/Sources/Ink/API/MarkdownParser.swift
+++ b/Sources/Ink/API/MarkdownParser.swift
@@ -67,9 +67,7 @@ public struct MarkdownParser {
                 let type = fragmentType(for: reader.currentCharacter,
                                         nextCharacter: reader.nextCharacter)
 
-                #if swift(>=5.4)
-                #warning("review compiler crash work-around below")
-                #elseif swift(>=5.3) && os(Linux)
+                #if swift(>=5.3) && swift(<5.4) && os(Linux)
                 // inline function call to work around https://bugs.swift.org/browse/SR-13645
                 let fragment: ParsedFragment = try {
                     let startIndex = reader.currentIndex


### PR DESCRIPTION
This fixes build errors with Xcode 12.5rc1. The Swift 5.3 workaround isn't needed anymore 🎉 