### PR TITLE
Remove the need of extra new line to render list and blockquote

### DIFF
--- a/Sources/Ink/Internal/FormattedText.swift
+++ b/Sources/Ink/Internal/FormattedText.swift
@@ -115,7 +115,7 @@ private extension FormattedText {
                             continue
                         }
 
-                        guard !nextCharacter.isAny(of: ["\n", "#", "<", "`"]) else {
+                        guard !nextCharacter.isAny(of: ["\n", "#", "<", "`", "-", ">"]) else {
                             break
                         }
 

--- a/Tests/InkTests/ListTests.swift
+++ b/Tests/InkTests/ListTests.swift
@@ -133,6 +133,18 @@ final class ListTests: XCTestCase {
 
         XCTAssertEqual(html, "<ul><li>One -Two</li><li>Three</li></ul>")
     }
+
+    func testListWithoutExtraNewLine() {
+        let html = MarkdownParser().html(from: """
+        Check the following:
+        - One
+        - Two
+        - Three
+        """)
+
+        XCTAssertEqual(html, "<p>Check the following:</p><ul><li>One</li><li>Two</li><li>Three</li></ul>")
+    }
+
 }
 
 extension ListTests {
@@ -148,7 +160,8 @@ extension ListTests {
             ("testMixedList", testMixedList),
             ("testUnorderedListWithMultiLineItem", testUnorderedListWithMultiLineItem),
             ("testUnorderedListWithNestedList", testUnorderedListWithNestedList),
-            ("testUnorderedListWithInvalidMarker", testUnorderedListWithInvalidMarker)
+            ("testUnorderedListWithInvalidMarker", testUnorderedListWithInvalidMarker),
+            ("testListWithoutExtraNewLine", testListWithoutExtraNewLine)
         ]
     }
 }

--- a/Tests/InkTests/TextFormattingTests.swift
+++ b/Tests/InkTests/TextFormattingTests.swift
@@ -148,6 +148,15 @@ final class TextFormattingTests: XCTestCase {
 
         XCTAssertEqual(html, "<p>Line 1<br>Line 2</p>")
     }
+
+    func testBlockquoteWithoutExtraNewLine() {
+        let html = MarkdownParser().html(from: """
+        Check this quote:
+        > The quick brown fox jumped over the lazy dog.
+        """)
+
+        XCTAssertEqual(html, "<p>Check this quote:</p><blockquote><p>The quick brown fox jumped over the lazy dog.</p></blockquote>")
+    }
 }
 
 extension TextFormattingTests {
@@ -178,7 +187,8 @@ extension TextFormattingTests {
             ("testMultiLineBlockquote", testMultiLineBlockquote),
             ("testEscapingSymbolsWithBackslash", testEscapingSymbolsWithBackslash),
             ("testDoubleSpacedHardLinebreak", testDoubleSpacedHardLinebreak),
-            ("testEscapedHardLinebreak", testEscapedHardLinebreak)
+            ("testEscapedHardLinebreak", testEscapedHardLinebreak),
+            ("testBlockquoteWithoutExtraNewLine", testBlockquoteWithoutExtraNewLine)
         ]
     }
 }


### PR DESCRIPTION
Currently, parsing this:
```
Check the following:
- One
- Two
- Three
```
will produce:
```
<p>Check the following: - One - Two - Three</p>
```

But I think, it should be like:
```
<p>Check the following:</p>
<ul>
   <li>One</li>
   <li>Two</li>
   <li>Three</li>
</ul>
```

just like here in GIthub 👇

Check the following:
- One
- Two
- Three