### PR TITLE
Added logic to allow Metadata values to be split over several lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ To define metadata values within a Markdown document, use the following syntax:
 ```
 ---
 keyA: valueA
-keyB: valueB
+keyB: a value can be
+  split into multiple lines by using two spaces
+  at the beggining of the follwing lines
+keyC: valueC
 ---
 
 Markdown text...

--- a/Sources/Ink/Internal/Metadata.swift
+++ b/Sources/Ink/Internal/Metadata.swift
@@ -15,23 +15,32 @@ internal struct Metadata: Readable {
         var lastKey: String?
 
         while !reader.didReachEnd {
+            let whiteSpaceCount = reader.readCount(of: " ")
             reader.discardWhitespacesAndNewlines()
 
             guard reader.currentCharacter != "-" else {
                 try require(reader.readCount(of: "-") == 3)
                 return metadata
             }
-
+            
+            guard whiteSpaceCount != 2 else{
+                if let lastKey = lastKey {
+                    let restOfValue = trim(reader.readUntilEndOfLine())
+                    metadata.values[lastKey]?.append(" " + restOfValue)
+                }
+                continue
+            }
+            
             let key = try trim(reader.read(until: ":", required: false))
-
-            guard reader.previousCharacter == ":" else {
+            
+            guard reader.previousCharacter == ":" else{
                 if let lastKey = lastKey {
                     metadata.values[lastKey]?.append(" " + key)
                 }
-
                 continue
             }
 
+            
             let value = trim(reader.readUntilEndOfLine())
 
             if !value.isEmpty {

--- a/Tests/InkTests/MarkdownTests.swift
+++ b/Tests/InkTests/MarkdownTests.swift
@@ -66,6 +66,19 @@ final class MarkdownTests: XCTestCase {
         XCTAssertEqual(markdown.metadata, [:])
         XCTAssertEqual(markdown.html, "<h1>Title</h1>")
     }
+    
+    func testMultilineMetadataWithColonInValue(){
+        let markdown = MarkdownParser().parse("""
+        ---
+        a: 1
+          b:2
+        ---
+        # Title
+        """)
+
+        XCTAssertEqual(markdown.metadata, ["a": "1 b:2"])
+        XCTAssertEqual(markdown.html, "<h1>Title</h1>")
+    }
 
     func testMetadataModifiers() {
         let parser = MarkdownParser(modifiers: [
@@ -138,6 +151,7 @@ extension MarkdownTests {
             ("testDiscardingEmptyMetadataValues", testDiscardingEmptyMetadataValues),
             ("testMergingOrphanMetadataValueIntoPreviousOne", testMergingOrphanMetadataValueIntoPreviousOne),
             ("testMissingMetadata", testMissingMetadata),
+            ("testMultilineMetadataWithColonInValue", testMultilineMetadataWithColonInValue),
             ("testMetadataModifiers", testMetadataModifiers),
             ("testPlainTextTitle", testPlainTextTitle),
             ("testRemovingTrailingMarkersFromTitle", testRemovingTrailingMarkersFromTitle),


### PR DESCRIPTION
 In most cases, multiline values already worked ([see here](https://github.com/JohnSundell/Ink/blob/77c3d8953374a9cf5418ef0bd7108524999de85a/Tests/InkTests/MarkdownTests.swift#L46))except when a colon was intended to be part of the value in one of the following lines. This used to be interpreted as a new key/value pair.

With this change, all lines starting with 2 spaces will be interpreted as part of the value for the previous key, even if there is a colon in the line.