### PR TITLE
Typo on READ.ME

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Ink supports the following Markdown features:
 - Italic text, by surrounding a piece of text with either an asterisk (`*`), or an underscore (`_`). For example `*Italic text*`.
 - Bold text, by surrounding a piece of text with either two asterisks (`**`), or two underscores (`__`). For example `**Bold text**`.
 - Text strikethrough, by surrounding a piece of text with two tildes (`~~`), for example `~~Strikethrough text~~`.
-- Inline code, marked with a backtick on either site of the code.
+- Inline code, marked with a backtick on either side of the code.
 - Code blocks, marked with three or more backticks both above and below the block.
 - Links, using the following syntax: `[Title](url)`.
 - Images, using the following syntax: `![Alt text](image-url)`.


### PR DESCRIPTION
Instead of: 
- Inline code, marked with a backtick on either site of the code.
change to:
- Inline code, marked with a backtick on either side of the code.