### PR TITLE
Support Links with parenthesis

### DIFF
--- a/Sources/Ink/Internal/Link.swift
+++ b/Sources/Ink/Internal/Link.swift
@@ -19,7 +19,7 @@ internal struct Link: Fragment {
 
         if reader.currentCharacter == "(" {
             reader.advanceIndex()
-            let url = try reader.read(until: ")")
+            let url = try reader.read(until: ")", balanceAgainst: "(")
             return Link(target: .url(url), text: text)
         } else {
             try reader.read("[")

--- a/Sources/Ink/Internal/Reader.swift
+++ b/Sources/Ink/Internal/Reader.swift
@@ -37,11 +37,13 @@ extension Reader {
     mutating func read(until character: Character,
                        required: Bool = true,
                        allowWhitespace: Bool = true,
-                       allowLineBreaks: Bool = false) throws -> Substring {
+                       allowLineBreaks: Bool = false,
+                       balanceAgainst balancingCharacter: Character? = nil) throws -> Substring {
         let startIndex = currentIndex
+        var characterBalance = 0
 
         while !didReachEnd {
-            guard currentCharacter != character else {
+            guard currentCharacter != character || characterBalance > 0 else {
                 let result = string[startIndex..<currentIndex]
                 advanceIndex()
                 return result
@@ -53,6 +55,16 @@ extension Reader {
 
             if !allowLineBreaks, currentCharacter.isNewline {
                 break
+            }
+
+            if let balancingCharacter = balancingCharacter {
+                if currentCharacter == balancingCharacter {
+                    characterBalance += 1
+                }
+
+                if currentCharacter == character {
+                    characterBalance -= 1
+                }
             }
 
             advanceIndex()

--- a/Tests/InkTests/LinkTests.swift
+++ b/Tests/InkTests/LinkTests.swift
@@ -60,6 +60,21 @@ final class LinkTests: XCTestCase {
         XCTAssertEqual(html, "<p><a href=\"/he_llo\">He_llo</a></p>")
     }
 
+    func testLinkWithParenthesis() {
+        let html = MarkdownParser().html(from: "[Hello](/(hello))")
+        XCTAssertEqual(html, "<p><a href=\"/(hello)\">Hello</a></p>")
+    }
+
+    func testLinkWithNestedParenthesis() {
+        let html = MarkdownParser().html(from: "[Hello](/(h(e(l(l(o()))))))")
+        XCTAssertEqual(html, "<p><a href=\"/(h(e(l(l(o())))))\">Hello</a></p>")
+    }
+
+    func testLinkWithParenthesisAndClosingParenthesisInContent() {
+        let html = MarkdownParser().html(from: "[Hello](/(hello)))")
+        XCTAssertEqual(html, "<p><a href=\"/(hello)\">Hello</a>)</p>")
+    }
+
     func testUnterminatedLink() {
         let html = MarkdownParser().html(from: "[Hello]")
         XCTAssertEqual(html, "<p>[Hello]</p>")
@@ -81,6 +96,9 @@ extension LinkTests {
             ("testBoldLinkWithInternalMarkers", testBoldLinkWithInternalMarkers),
             ("testBoldLinkWithExternalMarkers", testBoldLinkWithExternalMarkers),
             ("testLinkWithUnderscores", testLinkWithUnderscores),
+            ("testLinkWithParenthesis", testLinkWithParenthesis),
+            ("testLinkWithNestedParenthesis", testLinkWithNestedParenthesis),
+            ("testLinkWithParenthesisAndClosingParenthesisInContent", testLinkWithParenthesisAndClosingParenthesisInContent),
             ("testUnterminatedLink", testUnterminatedLink),
             ("testLinkWithEscapedSquareBrackets", testLinkWithEscapedSquareBrackets)
         ]


### PR DESCRIPTION
# PROBLEM

Ink does not currently parse URLs with parenthesis `()` correctly, because it reads until the first closing parenthesis `)`.

## Example
Wikipedia has numerous links like this.
Github parsing: [markdown example](https://en.wikipedia.org/wiki/Service_(systems_architecture))
Raw markdown: `[markdown example](https://en.wikipedia.org/wiki/Service_(systems_architecture))`

# SOLUTION

Use a balancing approach and count how many new opening parenthesis `(` appear to ensure that reading continues until the final closing parenthesis is encountered.

# Other solutions

I saw that there was already a PR that was a couple years old [by nickd](https://github.com/JohnSundell/Ink/pull/50) that hadn't been merged.  It took the approach of counting opening parenthesis after reading ended, then continue reading until the final parenthesis is closed (accounting for new opening parenthesis).

I tried my tests on both solutions, and they both pass.  I also ran some performance tests and they are essentially equal (0.0000X difference) in that regard.

If that solution is merged instead, I'm happy to close this PR.

Feel free to make any changes you want to the PR.